### PR TITLE
README: add links to generated documentations on Bump.sh

### DIFF
--- a/apis/README.md
+++ b/apis/README.md
@@ -4,3 +4,8 @@ This directory holds OpenAPI & AsyncAPI contract file examples for
 “standalone” APIs (single contract file) which are deployed to
 [bump.sh](https://bump.sh) to generate elegant and always up-to-date
 API documentation.
+
+The files are automatically deployed to Bump.sh:
+
+- Bump official documentation: https://developers.bump.sh/
+- Twitter API v2 documentation: https://bump.sh/demo/doc/twitter-api-v2

--- a/hubs/amadeus/README.md
+++ b/hubs/amadeus/README.md
@@ -1,2 +1,3 @@
 This is an unofficial developer portal for Amadeus API contracts (OpenAPI) taken from <https://developers.amadeus.com/self-service/category/air>
 
+It is automatically deployed from the OpenAPI contracts in this directory to <https://bump.sh/demo/hub/amadeus>.

--- a/hubs/examples/README.md
+++ b/hubs/examples/README.md
@@ -1,0 +1,3 @@
+This is an examples Hub which we use internally at Bump to test different specification features.
+
+It is automatically deployed from the OpenAPI & AsyncAPI contracts in this directory to <https://bump.sh/hub/examples>.

--- a/hubs/my-train-company/README.md
+++ b/hubs/my-train-company/README.md
@@ -1,0 +1,3 @@
+This is a demo Hub which we use at Bump to showcase all the features offered by the Bump.sh product.
+
+It is automatically deployed from the OpenAPI & AsyncAPI contracts in this directory to <https://demo.bump.sh/>.

--- a/hubs/scaleway-developers/README.md
+++ b/hubs/scaleway-developers/README.md
@@ -8,3 +8,5 @@ This is an unofficial developer portal for Scaleway API contracts (OpenAPI) take
 - Kubernetes Kapsule API
 - Private networks VPC API
 - DNS API
+
+It is automatically deployed from the OpenAPI contracts in this directory to <https://bump.sh/demo/hub/scaleway-developers>.

--- a/hubs/zbos-mqtt/README.md
+++ b/hubs/zbos-mqtt/README.md
@@ -1,1 +1,3 @@
 This is an unofficial developer portal for Zora Bots API contracts (AsyncAPI) taken from <https://docs.zorabots.be/dev-mqtt-docs/latest/index.html>
+
+It is automatically deployed from the AsyncAPI contracts in this directory to <https://bump.sh/demo/hub/zbos-mqtt>.


### PR DESCRIPTION
This commit adds links in READMEs for each Hubs & Apis contracts from
this repository. This can help a curious person browsing the
repository to see the resulting docs / hubs on Bump.