### PR TITLE
Integrate Swagger examples from Bump codebase

### DIFF
--- a/hubs/swagger/github.json
+++ b/hubs/swagger/github.json
@@ -1,0 +1,24745 @@
+{
+  "swagger": "2.0",
+  "schemes": [
+    "https"
+  ],
+  "host": "api.github.com",
+  "basePath": "/",
+  "x-hasEquivalentPaths": true,
+  "info": {
+    "description": "Powerful collaboration, code review, and code management for open source and private projects.\n",
+    "termsOfService": "https://help.github.com/articles/github-terms-of-service/#b-api-terms",
+    "title": "GitHub",
+    "version": "v3",
+    "x-apisguru-categories": [
+      "collaboration",
+      "developer_tools"
+    ],
+    "x-logo": {
+      "url": "https://api.apis.guru/v2/cache/logo/http_assets-cdn.github.com_images_modules_logos_page_GitHub-Mark.png"
+    },
+    "x-origin": [
+      {
+        "format": "swagger",
+        "url": "https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/github.com/v3/swagger.yaml",
+        "version": "2.0"
+      }
+    ],
+    "x-preferred": true,
+    "x-providerName": "github.com",
+    "x-unofficialSpec": true
+  },
+  "externalDocs": {
+    "url": "https://developer.github.com/v3/"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "oauth_2_0": {
+      "authorizationUrl": "https://github.com/login/oauth/authorize",
+      "description": "OAuth2 is a protocol that lets external apps request authorization to private\ndetails in a user's GitHub account without getting their password. This is\npreferred over Basic Authentication because tokens can be limited to specific\ntypes of data, and can be revoked by users at any time.\n",
+      "flow": "accessCode",
+      "scopes": {
+        "admin:org": "",
+        "admin:org_hook": "",
+        "admin:public_key": "",
+        "admin:repo_hook": "",
+        "delete_repo": "",
+        "gist": "",
+        "notifications": "",
+        "public_repo": "",
+        "read:org": "",
+        "read:public_key": "",
+        "read:repo_hook": "",
+        "repo": "",
+        "repo:status": "",
+        "repo_deployment": "",
+        "user": "",
+        "user:email": "",
+        "user:follow": "",
+        "write:org": "",
+        "write:public_key": "",
+        "write:repo_hook": ""
+      },
+      "tokenUrl": "https://github.com/login/oauth/access_token",
+      "type": "oauth2"
+    }
+  },
+  "paths": {
+    "/emojis": {
+      "get": {
+        "description": "Lists all the emojis available to use on GitHub.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/emojis"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/events": {
+      "get": {
+        "description": "List public events.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/feeds": {
+      "get": {
+        "description": "List Feeds.\nGitHub provides several timeline resources in Atom format. The Feeds API\n lists all the feeds available to the authenticating user.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/feeds"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists": {
+      "get": {
+        "description": "List the authenticated user's gists or if called anonymously, this will\nreturn all public gists.\n",
+        "parameters": [
+          {
+            "description": "Timestamp in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.\nOnly gists updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a gist.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postGist"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/gist"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists/public": {
+      "get": {
+        "description": "List all public gists.",
+        "parameters": [
+          {
+            "description": "Timestamp in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.\nOnly gists updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists/starred": {
+      "get": {
+        "description": "List the authenticated user's starred gists.",
+        "parameters": [
+          {
+            "description": "Timestamp in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.\nOnly gists updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists/{id}": {
+      "delete": {
+        "description": "Delete a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gist"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/patchGist"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gist"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists/{id}/comments": {
+      "get": {
+        "description": "List comments on a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/comments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a commen",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists/{id}/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a comment.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single comment.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a comment.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/comment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gists/{id}/forks": {
+      "post": {
+        "description": "Fork a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Exists."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Not exists."
+          }
+        }
+      }
+    },
+    "/gists/{id}/star": {
+      "delete": {
+        "description": "Unstar a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item removed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if a gist is starred.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Exists."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Not exists."
+          }
+        }
+      },
+      "put": {
+        "description": "Star a gist.",
+        "parameters": [
+          {
+            "description": "Id of gist.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Starred."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gitignore/templates": {
+      "get": {
+        "description": "Listing available templates.\nList all templates available to pass as an option when creating a repository.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/gitignore/templates/{language}": {
+      "get": {
+        "description": "Get a single template.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "language",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore-lang"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/issues": {
+      "get": {
+        "description": "List issues.\nList all issues across all the authenticated user's visible repositories.\n",
+        "parameters": [
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": [
+              "assigned",
+              "created",
+              "mentioned",
+              "subscribed",
+              "all"
+            ],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": [
+              "created",
+              "updated",
+              "comments"
+            ],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/legacy/issues/search/{owner}/{repository}/{state}/{keyword}": {
+      "get": {
+        "description": "Find issues by state and keyword.",
+        "parameters": [
+          {
+            "description": "The search term.",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Indicates the state of the issues to return. Can be either open or closed.",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "path",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "repository",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-issues-by-keyword"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/legacy/repos/search/{keyword}": {
+      "get": {
+        "description": "Find repositories by keyword. Note, this legacy method does not follow the v3 pagination pattern. This method returns up to 100 results per page and pages can be fetched using the start_page parameter.",
+        "parameters": [
+          {
+            "description": "The search term",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "Filter results by language",
+            "in": "query",
+            "name": "language",
+            "type": "string"
+          },
+          {
+            "description": "The page number to fetch",
+            "in": "query",
+            "name": "start_page",
+            "type": "string"
+          },
+          {
+            "description": "The sort field. One of stars, forks, or updated. Default: results are sorted by best match.",
+            "enum": [
+              "updated",
+              "stars",
+              "forks"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-repositories-by-keyword"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/legacy/user/email/{email}": {
+      "get": {
+        "description": "This API call is added for compatibility reasons only.",
+        "parameters": [
+          {
+            "description": "The email address",
+            "in": "path",
+            "name": "email",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-user-by-email"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/legacy/user/search/{keyword}": {
+      "get": {
+        "description": "Find users by keyword.",
+        "parameters": [
+          {
+            "description": "The search term",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The page number to fetch",
+            "in": "query",
+            "name": "start_page",
+            "type": "string"
+          },
+          {
+            "description": "The sort field. One of stars, forks, or updated. Default: results are sorted by best match.",
+            "enum": [
+              "updated",
+              "stars",
+              "forks"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-users-by-keyword"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/markdown": {
+      "post": {
+        "description": "Render an arbitrary Markdown document",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/markdown"
+            }
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/markdown/raw": {
+      "post": {
+        "consumes": [
+          "text/plain"
+        ],
+        "description": "Render a Markdown document in raw mode",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/meta": {
+      "get": {
+        "description": "This gives some information about GitHub.com, the service.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/meta"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/networks/{owner}/{repo}/events": {
+      "get": {
+        "description": "List public events for a network of repositories.",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "description": "List your notifications.\nList all notifications for the current user, grouped by repository.\n",
+        "parameters": [
+          {
+            "description": "True to show notifications marked as read.",
+            "in": "query",
+            "name": "all",
+            "type": "boolean"
+          },
+          {
+            "description": "True to show only notifications in which the user is directly participating\nor mentioned.\n",
+            "in": "query",
+            "name": "participating",
+            "type": "boolean"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "put": {
+        "description": "Mark as read.\nMarking a notification as \"read\" removes it from the default view on GitHub.com.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/notificationMarkRead"
+            }
+          }
+        ],
+        "responses": {
+          "205": {
+            "description": "Marked as read."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/notifications/threads/{id}": {
+      "get": {
+        "description": "View a single thread.",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Mark a thread as read",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "205": {
+            "description": "Thread marked as read."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/notifications/threads/{id}/subscription": {
+      "delete": {
+        "description": "Delete a Thread Subscription.",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a Thread Subscription.",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/subscription"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "put": {
+        "description": "Set a Thread Subscription.\nThis lets you subscribe to a thread, or ignore it. Subscribing to a thread\nis unnecessary if the user is already subscribed to the repository. Ignoring\na thread will mute all future notifications (until you comment or get @mentioned).\n",
+        "parameters": [
+          {
+            "description": "Id of thread.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/subscription"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}": {
+      "get": {
+        "description": "Get an Organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/organization"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit an Organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/patchOrg"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/organization"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/events": {
+      "get": {
+        "description": "List public events for an organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/issues": {
+      "get": {
+        "description": "List issues.\nList all issues for a given organization for the authenticated user.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": [
+              "assigned",
+              "created",
+              "mentioned",
+              "subscribed",
+              "all"
+            ],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": [
+              "created",
+              "updated",
+              "comments"
+            ],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/members": {
+      "get": {
+        "description": "Members list.\nList all users who are members of an organization. A member is a user tha\nbelongs to at least 1 team in the organization. If the authenticated user\nis also an owner of this organization then both concealed and public members\nwill be returned. If the requester is not an owner of the organization the\nquery will be redirected to the public members list.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "302": {
+            "description": "Response if requester is not an organization member."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/members/{username}": {
+      "delete": {
+        "description": "Remove a member.\nRemoving a user from this list will remove them from all teams and they\nwill no longer have any access to the organization's repositories.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if a user is, publicly or privately, a member of the organization.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content. Response if requester is an organization member and user is a member\n"
+          },
+          "302": {
+            "description": "Found. Response if requester is not an organization member\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Not Found.\na. Response if requester is an organization member and user is not a member\nb. Response if requester is not an organization member and is inquiring about themselves\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/public_members": {
+      "get": {
+        "description": "Public members list.\nMembers of an organization can choose to have their membership publicized\nor not.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/public_members/{username}": {
+      "delete": {
+        "description": "Conceal a user's membership.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Concealed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check public membership.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is a public member."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "User is not a public member."
+          }
+        }
+      },
+      "put": {
+        "description": "Publicize a user's membership.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Publicized."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/repos": {
+      "get": {
+        "description": "List repositories for the specified org.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "enum": [
+              "all",
+              "public",
+              "private",
+              "forks",
+              "sources",
+              "member"
+            ],
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new repository for the authenticated user. OAuth users must supply\nrepo scope.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postRepo"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/teams": {
+      "get": {
+        "description": "List teams.",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/teams"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create team.\nIn order to create a team, the authenticated user must be an owner of organization.\n",
+        "parameters": [
+          {
+            "description": "Name of organisation.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/orgTeamsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/team"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/rate_limit": {
+      "get": {
+        "description": "Get your current rate limit status\nNote: Accessing this endpoint does not count against your rate limit.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/rate_limit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}": {
+      "delete": {
+        "description": "Delete a Repository.\nDeleting a repository requires admin access. If OAuth is used, the delete_repo\nscope is required.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item removed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/repoEdit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/assignees": {
+      "get": {
+        "description": "List assignees.\nThis call lists all the available assignees (owner + collaborators) to which\nissues may be assigned.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/assignees"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/assignees/{assignee}": {
+      "get": {
+        "description": "Check assignee.\nYou may also check to see if a particular user is an assignee for a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the assignee.",
+            "in": "path",
+            "name": "assignee",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is an assignee."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "User isn't an assignee."
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/branches": {
+      "get": {
+        "description": "Get list of branches",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/branches"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/branches/{branch}": {
+      "get": {
+        "description": "Get Branch",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the branch.",
+            "in": "path",
+            "name": "branch",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/branch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/collaborators": {
+      "get": {
+        "description": "List.\nWhen authenticating as an organization owner of an organization-owned\nrepository, all organization owners are included in the list of\ncollaborators. Otherwise, only users with access to the repository are\nreturned in the collaborators list.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/collaborators/{user}": {
+      "delete": {
+        "description": "Remove collaborator.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the user.",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Collaborator removed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if user is a collaborator",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the user.",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is a collaborator."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "User is not a collaborator."
+          }
+        }
+      },
+      "put": {
+        "description": "Add collaborator.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Login of the user.",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Collaborator added."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/comments": {
+      "get": {
+        "description": "List commit comments for a repository.\nComments are ordered by ascending ID.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repoComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a commit comment",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single commit comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/commitComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a commit comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/commitComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits": {
+      "get": {
+        "description": "List commits on a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "Sha or branch to start listing commits from.",
+            "in": "query",
+            "name": "sha",
+            "type": "string"
+          },
+          {
+            "description": "Only commits containing this file path will be returned.",
+            "in": "query",
+            "name": "path",
+            "type": "string"
+          },
+          {
+            "description": "GitHub login, name, or email by which to filter by commit author.",
+            "in": "query",
+            "name": "author",
+            "type": "string"
+          },
+          {
+            "description": "ISO 8601 Date - Only commits before this date will be returned.",
+            "in": "query",
+            "name": "until",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/commits"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits/{ref}/status": {
+      "get": {
+        "description": "Get the combined Status for a specific Ref\nThe Combined status endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the blog post for full details.\nTo access this endpoint during the preview period, you must provide a custom media type in the Accept header:\napplication/vnd.github.she-hulk-preview+json\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/refStatus"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits/{shaCode}": {
+      "get": {
+        "description": "Get a single commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code of the commit.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/commit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/commits/{shaCode}/comments": {
+      "get": {
+        "description": "List comments for a single commitList comments for a single commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code of the commit.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repoComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a commit comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code of the commit.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commitBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/commitComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/compare/{baseId}...{headId}": {
+      "get": {
+        "description": "Compare two commits",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "baseId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "headId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/compare-commits"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/contents/{path}": {
+      "delete": {
+        "description": "Delete a file.\nThis method deletes a file in a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/deleteFileBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/deleteFile"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get contents.\nThis method returns the contents of a file or directory in a repository.\nFiles and symlinks support a custom media type for getting the raw content.\nDirectories and submodules do not support custom media types.\nNote: This API supports files up to 1 megabyte in size.\nHere can be many outcomes. For details see \"http://developer.github.com/v3/repos/contents/\"\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The content path.",
+            "in": "query",
+            "name": "path",
+            "type": "string"
+          },
+          {
+            "description": "The String name of the Commit/Branch/Tag. Defaults to 'master'.",
+            "in": "query",
+            "name": "ref",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/contents-path"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "put": {
+        "description": "Create a file.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/createFileBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/createFile"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/contributors": {
+      "get": {
+        "description": "Get list of contributors.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Set to 1 or true to include anonymous contributors in results.",
+            "in": "query",
+            "name": "anon",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/contributors"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/deployments": {
+      "get": {
+        "description": "Users with pull access can view deployments for a repository",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repo-deployments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Users with push access can create a deployment for a given ref",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/deployment"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/deployment-resp"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/deployments/{id}/statuses": {
+      "get": {
+        "description": "Users with pull access can view deployment statuses for a deployment",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The Deployment ID to list the statuses from.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/deployment-statuses"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a Deployment Status\nUsers with push access can create deployment statuses for a given deployment:\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The Deployment ID to list the statuses from.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/deployment-statuses-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "ok"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/downloads": {
+      "get": {
+        "description": "Deprecated. List downloads for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/downloads"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/downloads/{downloadId}": {
+      "delete": {
+        "description": "Deprecated. Delete a download.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of download.",
+            "in": "path",
+            "name": "downloadId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Deprecated. Get a single download.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of download.",
+            "in": "path",
+            "name": "downloadId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/downloads"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/events": {
+      "get": {
+        "description": "Get list of repository events.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/forks": {
+      "get": {
+        "description": "List forks.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "newes",
+            "enum": [
+              "newes",
+              "oldes",
+              "watchers"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/forks"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a fork.\nForking a Repository happens asynchronously. Therefore, you may have to wai\na short period before accessing the git objects. If this takes longer than 5\nminutes, be sure to contact Support.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/forkBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/fork"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/blobs": {
+      "post": {
+        "description": "Create a Blob.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/blob"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/blobs"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/blobs/{shaCode}": {
+      "get": {
+        "description": "Get a Blob.\nSince blobs can be any arbitrary binary data, the input and responses for\nthe blob API takes an encoding parameter that can be either utf-8 or\nbase64. If your data cannot be losslessly sent as a UTF-8 string, you can\nbase64 encode it.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/blob"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/commits": {
+      "post": {
+        "description": "Create a Commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/repoCommitBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/gitCommit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/commits/{shaCode}": {
+      "get": {
+        "description": "Get a Commit.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "SHA-1 code.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repoCommit"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/refs": {
+      "get": {
+        "description": "Get all References",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/refs"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a Reference",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/refsBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/refs/{ref}": {
+      "delete": {
+        "description": "Delete a Reference\nExample: Deleting a branch: DELETE /repos/octocat/Hello-World/git/refs/heads/feature-a \nExample: Deleting a tag:        DELETE /repos/octocat/Hello-World/git/refs/tags/v1.0\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a Reference",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a Reference",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/gitRefPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/tags": {
+      "post": {
+        "description": "Create a Tag Object.\nNote that creating a tag object does not create the reference that makes a\ntag in Git. If you want to create an annotated tag in Git, you have to do\nthis call to create the tag object, and then create the refs/tags/[tag]\nreference. If you want to create a lightweight tag, you only have to create\nthe tag reference - this call would be unnecessary.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tag"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/tags"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/tags/{shaCode}": {
+      "get": {
+        "description": "Get a Tag.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/tag"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/trees": {
+      "post": {
+        "description": "Create a Tree.\nThe tree creation API will take nested entries as well. If both a tree and\na nested path modifying that tree are specified, it will overwrite the\ncontents of that tree with the new path contents and write a new tree out.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tree"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/trees"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/git/trees/{shaCode}": {
+      "get": {
+        "description": "Get a Tree.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Tree SHA.",
+            "in": "path",
+            "name": "shaCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Get a Tree Recursively. (0 or 1)",
+            "in": "query",
+            "name": "recursive",
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/tree"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/hooks": {
+      "get": {
+        "description": "Get list of hooks.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hookBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/hooks/{hookId}": {
+      "delete": {
+        "description": "Delete a hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get single hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a hook.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hookBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/hook"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/hooks/{hookId}/tests": {
+      "post": {
+        "description": "Test a push hook.\nThis will trigger the hook with the latest push to the current repository\nif the hook is subscribed to push events. If the hook is not subscribed\nto push events, the server will respond with 204 but no test POST will\nbe generated.\nNote: Previously /repos/:owner/:repo/hooks/:id/tes\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of hook.",
+            "in": "path",
+            "name": "hookId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Hook is triggered."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues": {
+      "get": {
+        "description": "List issues for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": [
+              "assigned",
+              "created",
+              "mentioned",
+              "subscribed",
+              "all"
+            ],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": [
+              "created",
+              "updated",
+              "comments"
+            ],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create an issue.\nAny user with pull access to a repository can create an issue.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/comments": {
+      "get": {
+        "description": "List comments in a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "description": "",
+            "enum": [
+              "created",
+              "updated"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issuesComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issuesComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ID of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issuesComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/events": {
+      "get": {
+        "description": "List issue events for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/events/{eventId}": {
+      "get": {
+        "description": "Get a single event.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of the event.",
+            "in": "path",
+            "name": "eventId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/event"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}": {
+      "get": {
+        "description": "Get a single issue",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit an issue.\nIssue owners and users with push access can edit an issue.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issue"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/comments": {
+      "get": {
+        "description": "List comments on an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issuesComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/issuesComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/events": {
+      "get": {
+        "description": "List events for an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/events"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/labels": {
+      "delete": {
+        "description": "Remove all labels from an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "List labels on an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/labels"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Add labels to an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "put": {
+        "description": "Replace all labels for an issue.\nSending an empty array ([]) will remove all Labels from the Issue.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/issues/{number}/labels/{name}": {
+      "delete": {
+        "description": "Remove a label from an issue.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of issue.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Item removed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/keys": {
+      "get": {
+        "description": "Get list of keys.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/keys"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a key.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-keys-post"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/keys/{keyId}": {
+      "delete": {
+        "description": "Delete a key.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a key",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/labels": {
+      "get": {
+        "description": "List all labels for this repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/labels"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/labels/{name}": {
+      "delete": {
+        "description": "Delete a label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a label.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of the label.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/label"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/languages": {
+      "get": {
+        "description": "List languages.\nList languages for the specified repository. The value on the right of a\nlanguage is the number of bytes of code written in that language.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/languages"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/merges": {
+      "post": {
+        "description": "Perform a merge.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/mergesBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response (The resulting merge commit)",
+            "schema": {
+              "$ref": "#/definitions/mergesSuccessful"
+            }
+          },
+          "204": {
+            "description": "No-op response (base already contains the head, nothing to merge)"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Missing base response or missing head response",
+            "schema": {
+              "$ref": "#/definitions/mergesConflict"
+            }
+          },
+          "409": {
+            "description": "Merge conflict response.",
+            "schema": {
+              "$ref": "#/definitions/mergesConflict"
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/milestones": {
+      "get": {
+        "description": "List milestones for a repository.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "description": "String to filter by state.",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "query",
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "default": "due_date",
+            "description": "",
+            "enum": [
+              "due_date",
+              "completeness"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/milestoneUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/milestones/{number}": {
+      "delete": {
+        "description": "Delete a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/milestoneUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/milestone"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/milestones/{number}/labels": {
+      "get": {
+        "description": "Get labels for every issue in a milestone.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Number of milestone.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/labels"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/notifications": {
+      "get": {
+        "description": "List your notifications in a repository\nList all notifications for the current user.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "True to show notifications marked as read.",
+            "in": "query",
+            "name": "all",
+            "type": "boolean"
+          },
+          {
+            "description": "True to show only notifications in which the user is directly participating\nor mentioned.\n",
+            "in": "query",
+            "name": "participating",
+            "type": "boolean"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "put": {
+        "description": "Mark notifications as read in a repository.\nMarking all notifications in a repository as \"read\" removes them from the\ndefault view on GitHub.com.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/notificationMarkRead"
+            }
+          }
+        ],
+        "responses": {
+          "205": {
+            "description": "Marked as read."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls": {
+      "get": {
+        "description": "List pull requests.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "description": "String to filter by state.",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "query",
+            "name": "state",
+            "type": "string"
+          },
+          {
+            "description": "Filter pulls by head user and branch name in the format of 'user:ref-name'.\nExample: github:new-script-format.\n",
+            "in": "query",
+            "name": "head",
+            "type": "string"
+          },
+          {
+            "description": "Filter pulls by base branch name. Example - gh-pages.",
+            "in": "query",
+            "name": "base",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pulls"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pullsPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/pulls"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/comments": {
+      "get": {
+        "description": "List comments in a repository.\nBy default, Review Comments are ordered by ascending ID.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "description": "",
+            "enum": [
+              "created",
+              "updated"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issuesComments"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/comments/{commentId}": {
+      "delete": {
+        "description": "Delete a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a comment.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of comment.",
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/commentBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}": {
+      "get": {
+        "description": "Get a single pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pullRequest"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pullUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repo"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/comments": {
+      "get": {
+        "description": "List comments on a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a comment.\n  #TODO Alternative input ( http://developer.github.com/v3/pulls/comments/ )\n  description: |\n    Alternative Input.\n    Instead of passing commit_id, path, and position you can reply to an\n    existing Pull Request Comment like this:\n\n        body\n           Required string\n        in_reply_to\n           Required number - Comment id to reply to.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pullsCommentPost"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/pullsComment"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/commits": {
+      "get": {
+        "description": "List commits on a pull request.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/commits"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/files": {
+      "get": {
+        "description": "List pull requests files.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pulls"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/pulls/{number}/merge": {
+      "get": {
+        "description": "Get if a pull request has been merged.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Pull request has been merged."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Pull request has not been merged."
+          }
+        }
+      },
+      "put": {
+        "description": "Merge a pull request (Merge Button's)",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Id of pull.",
+            "in": "path",
+            "name": "number",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/mergePullBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response if merge was successful.",
+            "schema": {
+              "$ref": "#/definitions/merge"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "405": {
+            "description": "Response if merge cannot be performed.",
+            "schema": {
+              "$ref": "#/definitions/merge"
+            }
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/readme": {
+      "get": {
+        "description": "Get the README.\nThis method returns the preferred README for a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The String name of the Commit/Branch/Tag. Defaults to master.",
+            "in": "query",
+            "name": "ref",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/contents-path"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases": {
+      "get": {
+        "description": "Users with push access to the repository will receive all releases (i.e., published releases and draft releases). Users with pull access will receive published releases only",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/releases"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a release\nUsers with push access to the repository can create a release.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/release-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/release"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases/assets/{id}": {
+      "delete": {
+        "description": "Delete a release asset",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single release asset",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/asset"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit a release asset\nUsers with push access to the repository can edit a release asset.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/assetPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/asset"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases/{id}": {
+      "delete": {
+        "description": "Users with push access to the repository can delete a release.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single release",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/release"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Users with push access to the repository can edit a release",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/release-create"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/release"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/releases/{id}/assets": {
+      "get": {
+        "description": "List assets for a release",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/assets"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stargazers": {
+      "get": {
+        "description": "List Stargazers.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/code_frequency": {
+      "get": {
+        "description": "Get the number of additions and deletions per week.\nReturns a weekly aggregate of the number of additions and deletions pushed\nto a repository.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/codeFrequencyStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/commit_activity": {
+      "get": {
+        "description": "Get the last year of commit activity data.\nReturns the last year of commit activity grouped by week. The days array\nis a group of commits per day, starting on Sunday.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/commitActivityStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/contributors": {
+      "get": {
+        "description": "Get contributors list with additions, deletions, and commit counts.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/contributorsStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/participation": {
+      "get": {
+        "description": "Get the weekly commit count for the repo owner and everyone else.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/participationStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/stats/punch_card": {
+      "get": {
+        "description": "Get the number of commits per hour in each day.\nEach array contains the day number, hour number, and number of commits\n0-6 Sunday - Saturday\n0-23 Hour of day\nNumber of commits\n\nFor example, [2, 14, 25] indicates that there were 25 total commits, during\nthe 2.00pm hour on Tuesdays. All times are based on the time zone of\nindividual commits.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/codeFrequencyStats"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/statuses/{ref}": {
+      "get": {
+        "description": "List Statuses for a specific Ref.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.\n",
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ref"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a Status.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Ref to list the statuses from. It can be a SHA, a branch name, or a tag name.\n",
+            "in": "path",
+            "name": "ref",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/headBranch"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ref"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/subscribers": {
+      "get": {
+        "description": "List watchers.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/subscription": {
+      "delete": {
+        "description": "Delete a Repository Subscription.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a Repository Subscription.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/subscribition"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "put": {
+        "description": "Set a Repository Subscription",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/subscribitionBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/subscribition"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/tags": {
+      "get": {
+        "description": "Get list of tags.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/tags"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/teams": {
+      "get": {
+        "description": "Get list of teams",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/teams"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/watchers": {
+      "get": {
+        "description": "List Stargazers. New implementation.",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repos/{owner}/{repo}/{archive_format}/{path}": {
+      "get": {
+        "description": "Get archive link.\nThis method will return a 302 to a URL to download a tarball or zipball\narchive for a repository. Please make sure your HTTP framework is\nconfigured to follow redirects or you will need to use the Location header\nto make a second GET request.\nNote: For private repositories, these links are temporary and expire quickly.\n",
+        "parameters": [
+          {
+            "description": "Name of repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "enum": [
+              "tarball",
+              "zipball"
+            ],
+            "in": "path",
+            "name": "archive_format",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Valid Git reference, defaults to 'master'.",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Found."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/repositories": {
+      "get": {
+        "description": "List all public repositories.\nThis provides a dump of every public repository, in the order that they\nwere created.\nNote: Pagination is powered exclusively by the since parameter. is the\nLink header to get the URL for the next page of repositories.\n",
+        "parameters": [
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repositories"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/search/code": {
+      "get": {
+        "description": "Search code.",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The search terms. This can be any combination of the supported code\nsearch parameters:\n'Search In' Qualifies which fields are searched. With this qualifier\nyou can restrict the search to just the file contents, the file path,\nor both.\n'Languages' Searches code based on the language it's written in.\n'Forks' Filters repositories based on the number of forks, and/or\nwhether code from forked repositories should be included in the results\nat all.\n'Size' Finds files that match a certain size (in bytes).\n'Path' Specifies the path that the resulting file must be at.\n'Extension' Matches files with a certain extension.\n'Users' or 'Repositories' Limits searches to a specific user or repository.\n",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Can only be 'indexed', which indicates how recently a file has been indexed\nby the GitHub search infrastructure. If not provided, results are sorted\nby best match.\n",
+            "enum": [
+              "indexed"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-code"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/search/issues": {
+      "get": {
+        "description": "Find issues by state and keyword. (This method returns up to 100 results per page.)",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The q search term can also contain any combination of the supported issue search qualifiers:",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The sort field. Can be comments, created, or updated. Default: results are sorted by best match.",
+            "enum": [
+              "updated",
+              "created",
+              "comments"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/search/repositories": {
+      "get": {
+        "description": "Search repositories.",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The search terms. This can be any combination of the supported repository\nsearch parameters:\n'Search In' Qualifies which fields are searched. With this qualifier you\ncan restrict the search to just the repository name, description, readme,\nor any combination of these.\n'Size' Finds repositories that match a certain size (in kilobytes).\n'Forks' Filters repositories based on the number of forks, and/or whether\nforked repositories should be included in the results at all.\n'Created' and 'Last Updated' Filters repositories based on times of\ncreation, or when they were last updated.\n'Users or Repositories' Limits searches to a specific user or repository.\n'Languages' Searches repositories based on the language they are written in.\n'Stars' Searches repositories based on the number of stars.\n",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "If not provided, results are sorted by best match.",
+            "enum": [
+              "stars",
+              "forks",
+              "updated"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-repositories"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/search/users": {
+      "get": {
+        "description": "Search users.",
+        "parameters": [
+          {
+            "default": "desc",
+            "description": "The sort field. if sort param is provided. Can be either asc or desc.",
+            "enum": [
+              "desc",
+              "asc"
+            ],
+            "in": "query",
+            "name": "order",
+            "type": "string"
+          },
+          {
+            "description": "The search terms. This can be any combination of the supported user\nsearch parameters:\n'Search In' Qualifies which fields are searched. With this qualifier you\ncan restrict the search to just the username, public email, full name,\nlocation, or any combination of these.\n'Repository count' Filters users based on the number of repositories they\nhave.\n'Location' Filter users by the location indicated in their profile.\n'Language' Search for users that have repositories that match a certain\nlanguage.\n'Created' Filter users based on when they joined.\n'Followers' Filter users based on the number of followers they have.\n",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "If not provided, results are sorted by best match.",
+            "enum": [
+              "followers",
+              "repositories",
+              "joined"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/search-users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/teams/{teamId}": {
+      "delete": {
+        "description": "Delete team.\nIn order to delete a team, the authenticated user must be an owner of the\norg that the team is associated with.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get team.",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/team"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Edit team.\nIn order to edit a team, the authenticated user must be an owner of the org\nthat the team is associated with.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/editTeam"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/team"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/members": {
+      "get": {
+        "description": "List team members.\nIn order to list members in a team, the authenticated user must be a member\nof the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/members/{username}": {
+      "delete": {
+        "description": "The \"Remove team member\" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Remove team membership API instead. It allows you to remove both active and pending memberships.\n\nRemove team member.\nIn order to remove a user from a team, the authenticated user must have 'admin'\npermissions to the team or be an owner of the org that the team is associated\nwith.\nNOTE This does not delete the user, it just remove them from the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team member removed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "The \"Get team member\" API is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Get team membership API instead. It allows you to get both active and pending memberships.\n\nGet team member.\nIn order to get if a user is a member of a team, the authenticated user mus\nbe a member of the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User is a member."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "User is not a member."
+          }
+        }
+      },
+      "put": {
+        "description": "The API (described below) is deprecated and is scheduled for removal in the next major version of the API. We recommend using the Add team membership API instead. It allows you to invite new organization members to your teams.\n\nAdd team member.\nIn order to add a user to a team, the authenticated user must have 'admin'\npermissions to the team or be an owner of the org that the team is associated\nwith.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team member added."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "422": {
+            "description": "If you attempt to add an organization to a team, you will get this.",
+            "schema": {
+              "$ref": "#/definitions/organizationAsTeamMember"
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/memberships/{username}": {
+      "delete": {
+        "description": "Remove team membership.\nIn order to remove a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with. NOTE: This does not delete the user, it just removes their membership from the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team member removed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get team membership.\nIn order to get a user's membership with a team, the authenticated user must be a member of the team or an owner of the team's organization.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User is a member.",
+            "schema": {
+              "$ref": "#/definitions/teamMembership"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "User has no membership with team"
+          }
+        }
+      },
+      "put": {
+        "description": "Add team membership.\nIn order to add a membership between a user and a team, the authenticated user must have 'admin' permissions to the team or be an owner of the organization that the team is associated with.\n\nIf the user is already a part of the team's organization (meaning they're on at least one other team in the organization), this endpoint will add the user to the team.\n\nIf the user is completely unaffiliated with the team's organization (meaning they're on none of the organization's teams), this endpoint will send an invitation to the user via email. This newly-created membership will be in the 'pending' state until the user accepts the invitation, at which point the membership will transition to the 'active' state and the user will be added as a member of the team.\n",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a member.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team member added.",
+            "schema": {
+              "$ref": "#/definitions/teamMembership"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "422": {
+            "description": "If you attempt to add an organization to a team, you will get this.",
+            "schema": {
+              "$ref": "#/definitions/organizationAsTeamMember"
+            }
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/repos": {
+      "get": {
+        "description": "List team repos",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/teamRepos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/repos/{org}/{repo}": {
+      "put": {
+        "description": "In order to add a repository to a team, the authenticated user must be an owner of the org that the team is associated with. Also, the repository must be owned by the organization, or a direct fork of a repository owned by the organization.",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a organization.",
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/teams/{teamId}/repos/{owner}/{repo}": {
+      "delete": {
+        "description": "In order to remove a repository from a team, the authenticated user must be an owner of the org that the team is associated with. NOTE: This does not delete the repository, it just removes it from the team.",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if a team manages a repository",
+        "parameters": [
+          {
+            "description": "Id of team.",
+            "in": "path",
+            "name": "teamId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "description": "Get the authenticated user.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "patch": {
+        "description": "Update the authenticated user.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-update"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/user"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/emails": {
+      "delete": {
+        "description": "Delete email address(es).\nYou can include a single email address or an array of addresses.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-emails"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "List email addresses for a user.\nIn the final version of the API, this method will return an array of hashes\nwith extended information for each email address indicating if the address\nhas been verified and if it's primary email address for GitHub.\nUntil API v3 is finalized, use the application/vnd.github.v3 media type to\nget other response format.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/vnd.github.v3"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/user-emails"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Add email address(es).\nYou can post a single email address or an array of addresses.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/emailsPost"
+            }
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/followers": {
+      "get": {
+        "description": "List the authenticated user's followers",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/following": {
+      "get": {
+        "description": "List who the authenticated user is following.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/following/{username}": {
+      "delete": {
+        "description": "Unfollow a user.\nUnfollowing a user requires the user to be logged in and authenticated with\nbasic auth or OAuth with the user:follow scope.\n",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User unfollowed."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if you are following a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response if you are following this user."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Response if you are not following this user."
+          }
+        }
+      },
+      "put": {
+        "description": "Follow a user.\nFollowing a user requires the user to be logged in and authenticated with\nbasic auth or OAuth with the user:follow scope.\n",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "You are now following the user."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/issues": {
+      "get": {
+        "description": "List issues.\nList all issues across owned and member repositories for the authenticated\nuser.\n",
+        "parameters": [
+          {
+            "default": "all",
+            "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
+            "enum": [
+              "assigned",
+              "created",
+              "mentioned",
+              "subscribed",
+              "all"
+            ],
+            "in": "query",
+            "name": "filter",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "open",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "String list of comma separated Label names. Example - bug,ui,@high.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "enum": [
+              "created",
+              "updated",
+              "comments"
+            ],
+            "in": "query",
+            "name": "sort",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "in": "query",
+            "name": "direction",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional string of a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nOnly issues updated at or after this time are returned.\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/issues"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/keys": {
+      "get": {
+        "description": "List your public keys.\nLists the current user's keys. Management of public keys via the API requires\nthat you are authenticated through basic auth, or OAuth with the 'user', 'write:public_key' scopes.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a public key.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/user-keys-post"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/keys/{keyId}": {
+      "delete": {
+        "description": "Delete a public key. Removes a public key. Requires that you are authenticated via Basic Auth or via OAuth with at least admin:public_key scope.",
+        "parameters": [
+          {
+            "description": "ID of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content.\n"
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Get a single public key.",
+        "parameters": [
+          {
+            "description": "ID of key.",
+            "in": "path",
+            "name": "keyId",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/user-keys-keyId"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/orgs": {
+      "get": {
+        "description": "List public and private organizations for the authenticated user.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/repos": {
+      "get": {
+        "description": "List repositories for the authenticated user. Note that this does not include\nrepositories owned by organizations which the user can access. You can lis\nuser organizations and list organization repositories separately.\n",
+        "parameters": [
+          {
+            "default": "all",
+            "enum": [
+              "all",
+              "public",
+              "private",
+              "forks",
+              "sources",
+              "member"
+            ],
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new repository for the authenticated user. OAuth users must supply\nrepo scope.\n",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postRepo"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/starred": {
+      "get": {
+        "description": "List repositories being starred by the authenticated user.",
+        "parameters": [
+          {
+            "description": "Ignored without 'sort' parameter.",
+            "in": "query",
+            "name": "direction",
+            "type": "string"
+          },
+          {
+            "default": "created",
+            "description": "",
+            "enum": [
+              "created",
+              "updated"
+            ],
+            "in": "query",
+            "name": "sort",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/starred/{owner}/{repo}": {
+      "delete": {
+        "description": "Unstar a repository",
+        "parameters": [
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unstarred."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if you are starring a repository.",
+        "parameters": [
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "This repository is starred by you."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "This repository is not starred by you."
+          }
+        }
+      },
+      "put": {
+        "description": "Star a repository.",
+        "parameters": [
+          {
+            "description": "Name of a repository owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of a repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Repository starred."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/subscriptions": {
+      "get": {
+        "description": "List repositories being watched by the authenticated user.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/user-userId-subscribitions"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/subscriptions/{owner}/{repo}": {
+      "delete": {
+        "description": "Stop watching a repository",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unwatched."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      },
+      "get": {
+        "description": "Check if you are watching a repository.",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Repository is watched by you."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Repository is not watched by you."
+          }
+        }
+      },
+      "put": {
+        "description": "Watch a repository.",
+        "parameters": [
+          {
+            "description": "Name of the owner.",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of repository.",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Repository is watched."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/user/teams": {
+      "get": {
+        "description": "List all of the teams across all of the organizations to which the authenticated user belongs. This method requires user or repo scope when authenticating via OAuth.",
+        "parameters": [
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/teams-list"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "description": "Get all users.\nThis provides a dump of every user, in the order that they signed up for GitHub.\nNote: Pagination is powered exclusively by the since parameter. Use the Link\nheader to get the URL for the next page of users.\n",
+        "parameters": [
+          {
+            "description": "The integer ID of the last User that you've seen.",
+            "in": "query",
+            "name": "since",
+            "type": "integer"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}": {
+      "get": {
+        "description": "Get a single user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/events": {
+      "get": {
+        "description": "If you are authenticated as the given user, you will see your private events. Otherwise, you'll only see public events.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/events/orgs/{org}": {
+      "get": {
+        "description": "This is the user's organization dashboard. You must be authenticated as the user to view this.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "org",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/followers": {
+      "get": {
+        "description": "List a user's followers",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/users"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/following/{targetUser}": {
+      "get": {
+        "description": "Check if one user follows another.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "targetUser",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Response if user follows target user."
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          },
+          "404": {
+            "description": "Response if user does not follow target user."
+          }
+        }
+      }
+    },
+    "/users/{username}/gists": {
+      "get": {
+        "description": "List a users gists.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The time should be passed in as UTC in the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\nExample: \"2012-10-09T23:39:01Z\".\n",
+            "in": "query",
+            "name": "since",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gists"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/keys": {
+      "get": {
+        "description": "List public keys for a user.\nLists the verified public keys for a user. This is accessible by anyone.\n",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/orgs": {
+      "get": {
+        "description": "List all public organizations for a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gitignore"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/received_events": {
+      "get": {
+        "description": "These are events that you'll only see public events.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/received_events/public": {
+      "get": {
+        "description": "List public events that a user has received",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/repos": {
+      "get": {
+        "description": "List public repositories for the specified user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": "all",
+            "enum": [
+              "all",
+              "public",
+              "private",
+              "forks",
+              "sources",
+              "member"
+            ],
+            "in": "query",
+            "name": "type",
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/repos"
+            }
+          },
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/starred": {
+      "get": {
+        "description": "List repositories being starred by a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    },
+    "/users/{username}/subscriptions": {
+      "get": {
+        "description": "List repositories being watched by a user.",
+        "parameters": [
+          {
+            "description": "Name of user.",
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "You can check the current version of media type in responses.\n",
+            "in": "header",
+            "name": "X-GitHub-Media-Type",
+            "type": "string"
+          },
+          {
+            "description": "Is used to set specified media type.",
+            "in": "header",
+            "name": "Accept",
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Limit",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Remaining",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-RateLimit-Reset",
+            "type": "integer"
+          },
+          {
+            "in": "header",
+            "name": "X-GitHub-Request-Id",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting\nfor details.\n"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "asset": {
+      "properties": {
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "download_count": {
+          "type": "number"
+        },
+        "id": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "type": "number"
+        },
+        "state": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "uploader": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "events_url": {
+              "type": "string"
+            },
+            "followers_url": {
+              "type": "string"
+            },
+            "following_url": {
+              "type": "string"
+            },
+            "gists_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "number"
+            },
+            "login": {
+              "type": "string"
+            },
+            "organizations_url": {
+              "type": "string"
+            },
+            "received_events_url": {
+              "type": "string"
+            },
+            "repos_url": {
+              "type": "string"
+            },
+            "site_admin": {
+              "type": "boolean"
+            },
+            "starred_url": {
+              "type": "string"
+            },
+            "subscriptions_url": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "assetPatch": {
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "assets": {
+      "items": {
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "download_count": {
+            "type": "number"
+          },
+          "id": {
+            "type": "number"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "state": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "uploader": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "events_url": {
+                "type": "string"
+              },
+              "followers_url": {
+                "type": "string"
+              },
+              "following_url": {
+                "type": "string"
+              },
+              "gists_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "number"
+              },
+              "login": {
+                "type": "string"
+              },
+              "organizations_url": {
+                "type": "string"
+              },
+              "received_events_url": {
+                "type": "string"
+              },
+              "repos_url": {
+                "type": "string"
+              },
+              "site_admin": {
+                "type": "boolean"
+              },
+              "starred_url": {
+                "type": "string"
+              },
+              "subscriptions_url": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "assignees": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "integer"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "blob": {
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "encoding": {
+          "enum": [
+            "utf-8",
+            "base64"
+          ]
+        },
+        "sha": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "blobs": {
+      "properties": {
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "branch": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "html": {
+              "type": "string"
+            },
+            "self": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "commit": {
+              "properties": {
+                "author": {
+                  "properties": {
+                    "date": {
+                      "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "committer": {
+                  "properties": {
+                    "date": {
+                      "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "tree": {
+                  "properties": {
+                    "sha": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "parents": {
+              "items": {
+                "properties": {
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "branches": {
+      "items": {
+        "properties": {
+          "commit": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "codeFrequencyStats": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "collaborators": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "comment": {
+      "properties": {
+        "body": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "commentBody": {
+      "properties": {
+        "body": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "type": "object"
+    },
+    "comments": {
+      "items": {
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601.",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "commit": {
+      "properties": {
+        "author": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "message": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "committer": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "files": {
+          "items": {
+            "properties": {
+              "additions": {
+                "type": "integer"
+              },
+              "blob_url": {
+                "type": "string"
+              },
+              "changes": {
+                "type": "integer"
+              },
+              "deletions": {
+                "type": "integer"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "patch": {
+                "type": "string"
+              },
+              "raw_url": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "parents": {
+          "items": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "stats": {
+          "properties": {
+            "additions": {
+              "type": "integer"
+            },
+            "deletions": {
+              "type": "integer"
+            },
+            "total": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "commitActivityStats": {
+      "items": {
+        "properties": {
+          "days": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "week": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "commitBody": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "line": {
+          "description": "Deprecated - Use position parameter instead.",
+          "type": "string"
+        },
+        "number": {
+          "description": "Line number in the file to comment on. Defaults to null.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Relative path of the file to comment on.",
+          "type": "string"
+        },
+        "position": {
+          "description": "Line index in the diff to comment on.",
+          "type": "integer"
+        },
+        "sha": {
+          "description": "SHA of the commit to comment on.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sha",
+        "body"
+      ],
+      "type": "object"
+    },
+    "commitComments": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "line": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "commits": {
+      "items": {
+        "properties": {
+          "author": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "commit": {
+            "properties": {
+              "author": {
+                "properties": {
+                  "date": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "committer": {
+                "properties": {
+                  "date": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "message": {
+                "type": "string"
+              },
+              "tree": {
+                "properties": {
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "committer": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "parents": {
+            "items": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "compare-commits": {
+      "properties": {
+        "ahead_by": {
+          "type": "integer"
+        },
+        "base_commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "events_url": {
+                  "type": "string"
+                },
+                "followers_url": {
+                  "type": "string"
+                },
+                "following_url": {
+                  "type": "string"
+                },
+                "gists_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "html_url": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "organizations_url": {
+                  "type": "string"
+                },
+                "received_events_url": {
+                  "type": "string"
+                },
+                "repos_url": {
+                  "type": "string"
+                },
+                "site_admin": {
+                  "type": "boolean"
+                },
+                "starred_url": {
+                  "type": "string"
+                },
+                "subscriptions_url": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "commit": {
+              "properties": {
+                "author": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "committer": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "tree": {
+                  "properties": {
+                    "sha": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "events_url": {
+                  "type": "string"
+                },
+                "followers_url": {
+                  "type": "string"
+                },
+                "following_url": {
+                  "type": "string"
+                },
+                "gists_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "html_url": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "organizations_url": {
+                  "type": "string"
+                },
+                "received_events_url": {
+                  "type": "string"
+                },
+                "repos_url": {
+                  "type": "string"
+                },
+                "site_admin": {
+                  "type": "boolean"
+                },
+                "starred_url": {
+                  "type": "string"
+                },
+                "subscriptions_url": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "parents": {
+              "items": {
+                "properties": {
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "behind_by": {
+          "type": "integer"
+        },
+        "commits": {
+          "items": {
+            "properties": {
+              "author": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "events_url": {
+                    "type": "string"
+                  },
+                  "followers_url": {
+                    "type": "string"
+                  },
+                  "following_url": {
+                    "type": "string"
+                  },
+                  "gists_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "organizations_url": {
+                    "type": "string"
+                  },
+                  "received_events_url": {
+                    "type": "string"
+                  },
+                  "repos_url": {
+                    "type": "string"
+                  },
+                  "site_admin": {
+                    "type": "boolean"
+                  },
+                  "starred_url": {
+                    "type": "string"
+                  },
+                  "subscriptions_url": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "commit": {
+                "properties": {
+                  "author": {
+                    "properties": {
+                      "date": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "committer": {
+                    "properties": {
+                      "date": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "tree": {
+                    "properties": {
+                      "sha": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "committer": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "events_url": {
+                    "type": "string"
+                  },
+                  "followers_url": {
+                    "type": "string"
+                  },
+                  "following_url": {
+                    "type": "string"
+                  },
+                  "gists_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "organizations_url": {
+                    "type": "string"
+                  },
+                  "received_events_url": {
+                    "type": "string"
+                  },
+                  "repos_url": {
+                    "type": "string"
+                  },
+                  "site_admin": {
+                    "type": "boolean"
+                  },
+                  "starred_url": {
+                    "type": "string"
+                  },
+                  "subscriptions_url": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "parents": {
+                "items": {
+                  "properties": {
+                    "sha": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "diff_url": {
+          "type": "string"
+        },
+        "files": {
+          "items": {
+            "properties": {
+              "additions": {
+                "type": "integer"
+              },
+              "blob_url": {
+                "type": "string"
+              },
+              "changes": {
+                "type": "integer"
+              },
+              "contents_url": {
+                "type": "string"
+              },
+              "deletions": {
+                "type": "integer"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "patch": {
+                "type": "string"
+              },
+              "raw_url": {
+                "type": "string"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "patch_url": {
+          "type": "string"
+        },
+        "permalink_url": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "total_commits": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "contents-path": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "git": {
+              "type": "string"
+            },
+            "html": {
+              "type": "string"
+            },
+            "self": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "git_url": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "contributors": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "contributions": {
+            "type": "integer"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "contributorsStats": {
+      "items": {
+        "properties": {
+          "author": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "total": {
+            "description": "The Total number of commits authored by the contributor.",
+            "type": "integer"
+          },
+          "weeks": {
+            "items": {
+              "properties": {
+                "a": {
+                  "description": "Number of additions.",
+                  "type": "integer"
+                },
+                "c": {
+                  "description": "Number of commits.",
+                  "type": "integer"
+                },
+                "d": {
+                  "description": "Number of deletions.",
+                  "type": "integer"
+                },
+                "w": {
+                  "description": "Start of the week.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "createDownload": {
+      "properties": {
+        "accesskeyid": {
+          "type": "string"
+        },
+        "acl": {
+          "type": "string"
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "download_count": {
+          "type": "integer"
+        },
+        "expirationdate": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "mime_type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "redirect": {
+          "type": "boolean"
+        },
+        "s3_url": {
+          "type": "string"
+        },
+        "signature": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "createFile": {
+      "properties": {
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "parents": {
+              "items": {
+                "properties": {
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "sha": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "properties": {
+            "_links": {
+              "properties": {
+                "git": {
+                  "type": "string"
+                },
+                "html": {
+                  "type": "string"
+                },
+                "self": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "git_url": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "createFileBody": {
+      "properties": {
+        "committer": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deleteFile": {
+      "properties": {
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "parents": {
+              "properties": {
+                "html_url": {
+                  "type": "string"
+                },
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deleteFileBody": {
+      "properties": {
+        "committer": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deployment": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "payload": {
+          "properties": {
+            "deploy_user": {
+              "type": "string"
+            },
+            "environment": {
+              "type": "string"
+            },
+            "room_id": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deployment-resp": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "creator": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "events_url": {
+              "type": "string"
+            },
+            "followers_url": {
+              "type": "string"
+            },
+            "following_url": {
+              "type": "string"
+            },
+            "gists_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "organizations_url": {
+              "type": "string"
+            },
+            "received_events_url": {
+              "type": "string"
+            },
+            "repos_url": {
+              "type": "string"
+            },
+            "site_admin": {
+              "type": "boolean"
+            },
+            "starred_url": {
+              "type": "string"
+            },
+            "subscriptions_url": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "payload": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "statuses_url": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "deployment-statuses": {
+      "items": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "creator": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "events_url": {
+                "type": "string"
+              },
+              "followers_url": {
+                "type": "string"
+              },
+              "following_url": {
+                "type": "string"
+              },
+              "gists_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "organizations_url": {
+                "type": "string"
+              },
+              "received_events_url": {
+                "type": "string"
+              },
+              "repos_url": {
+                "type": "string"
+              },
+              "site_admin": {
+                "type": "boolean"
+              },
+              "starred_url": {
+                "type": "string"
+              },
+              "subscriptions_url": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "target_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "deployment-statuses-create": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "target_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "downloadBody": {
+      "properties": {
+        "content_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "description": "Size of file in bytes.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "size"
+      ],
+      "type": "object"
+    },
+    "downloads": {
+      "properties": {
+        "content_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "download_count": {
+          "type": "integer"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "editTeam": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "permission": {
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "emailsPost": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "emojis": {
+      "properties": {
+        "100": {
+          "type": "string"
+        },
+        "1234": {
+          "type": "string"
+        },
+        "+1": {
+          "type": "string"
+        },
+        "-1": {
+          "type": "string"
+        },
+        "8ball": {
+          "type": "string"
+        },
+        "a": {
+          "type": "string"
+        },
+        "ab": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "event": {
+      "properties": {
+        "actor": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "event": {
+          "type": "string"
+        },
+        "issue": {
+          "properties": {
+            "assignee": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            "body": {
+              "type": "string"
+            },
+            "closed_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "comments": {
+              "type": "integer"
+            },
+            "created_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "labels": {
+              "items": {
+                "properties": {
+                  "color": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "milestone": {
+              "properties": {
+                "closed_issues": {
+                  "type": "integer"
+                },
+                "created_at": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "creator": {
+                  "properties": {
+                    "avatar_url": {
+                      "type": "string"
+                    },
+                    "gravatar_id": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "login": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "due_on": {
+                  "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                  "type": "string"
+                },
+                "number": {
+                  "type": "integer"
+                },
+                "open_issues": {
+                  "type": "integer"
+                },
+                "state": {
+                  "enum": [
+                    "open",
+                    "closed"
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "number": {
+              "type": "integer"
+            },
+            "pull_request": {
+              "properties": {
+                "diff_url": {
+                  "type": "string"
+                },
+                "html_url": {
+                  "type": "string"
+                },
+                "patch_url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "state": {
+              "enum": [
+                "open",
+                "closed"
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "updated_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "user": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "events": {
+      "properties": {
+        "actor": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "created_at": {
+          "type": "object"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "org": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "payload": {
+          "properties": {},
+          "type": "object"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "repo": {
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "feeds": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "current_user": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "current_user_actor": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "current_user_organization": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "current_user_public": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "timeline": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "user": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "current_user_actor_url": {
+          "type": "string"
+        },
+        "current_user_organization_url": {
+          "type": "string"
+        },
+        "current_user_public": {
+          "type": "string"
+        },
+        "current_user_url": {
+          "type": "string"
+        },
+        "timeline_url": {
+          "type": "string"
+        },
+        "user_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "fork": {
+      "properties": {
+        "clone_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fork": {
+          "type": "boolean"
+        },
+        "forks": {
+          "type": "integer"
+        },
+        "forks_count": {
+          "type": "integer"
+        },
+        "full_name": {
+          "type": "string"
+        },
+        "git_url": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "language": {
+          "type": "string"
+        },
+        "master_branch": {
+          "type": "string"
+        },
+        "mirror_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "open_issues": {
+          "type": "integer"
+        },
+        "open_issues_count": {
+          "type": "integer"
+        },
+        "owner": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "pushed_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "ssh_url": {
+          "type": "string"
+        },
+        "svn_url": {
+          "type": "string"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "watchers": {
+          "type": "integer"
+        },
+        "watchers_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "forkBody": {
+      "properties": {
+        "organization": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "forks": {
+      "items": {
+        "properties": {
+          "clone_url": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "fork": {
+            "type": "boolean"
+          },
+          "forks": {
+            "type": "integer"
+          },
+          "forks_count": {
+            "type": "integer"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "git_url": {
+            "type": "string"
+          },
+          "homepage": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "language": {
+            "type": "string"
+          },
+          "master_branch": {
+            "type": "string"
+          },
+          "mirror_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "open_issues": {
+            "type": "integer"
+          },
+          "open_issues_count": {
+            "type": "integer"
+          },
+          "owner": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "pushed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "ssh_url": {
+            "type": "string"
+          },
+          "svn_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "watchers": {
+            "type": "integer"
+          },
+          "watchers_count": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "gist": {
+      "properties": {
+        "comments": {
+          "type": "integer"
+        },
+        "comments_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "files": {
+          "properties": {
+            "ring.erl": {
+              "properties": {
+                "filename": {
+                  "type": "string"
+                },
+                "raw_url": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "forks": {
+          "items": {
+            "properties": {
+              "created_at": {
+                "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "git_pull_url": {
+          "type": "string"
+        },
+        "git_push_url": {
+          "type": "string"
+        },
+        "history": {
+          "items": {
+            "properties": {
+              "change_status": {
+                "properties": {
+                  "additions": {
+                    "type": "integer"
+                  },
+                  "deletions": {
+                    "type": "integer"
+                  },
+                  "total": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "committed_at": {
+                "description": "Timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "gists": {
+      "items": {
+        "properties": {
+          "comments": {
+            "type": "integer"
+          },
+          "comments_url": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "files": {
+            "properties": {
+              "ring.erl": {
+                "properties": {
+                  "filename": {
+                    "type": "string"
+                  },
+                  "raw_url": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "git_pull_url": {
+            "type": "string"
+          },
+          "git_push_url": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "gitCommit": {
+      "properties": {
+        "author": {
+          "properties": {
+            "date": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "type": "string"
+        },
+        "tree": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "gitRefPatch": {
+      "properties": {
+        "force": {
+          "type": "boolean"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "gitignore": {
+      "items": {},
+      "type": "array"
+    },
+    "gitignore-lang": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "headBranch": {
+      "properties": {
+        "object": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "headBranchBody": {
+      "properties": {
+        "force": {
+          "description": "Boolean indicating whether to force the update or to make sure the update is a fast-forward update. The default is false, so leaving this out or setting it to false will make sure you’re not overwriting work.",
+          "type": "boolean"
+        },
+        "sha": {
+          "description": "String of the SHA1 value to set this reference to.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sha",
+        "force"
+      ],
+      "type": "object"
+    },
+    "heads": {
+      "items": {
+        "properties": {
+          "commit": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tarball_url": {
+            "type": "string"
+          },
+          "zipball_url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "hook": {
+      "items": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "config": {
+            "properties": {
+              "content_type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "enum": [
+                "push",
+                "issues",
+                "issue_comment",
+                "commit_comment",
+                "pull_request",
+                "pull_request_review_comment",
+                "gollum",
+                "watch",
+                "download",
+                "fork",
+                "fork_apply",
+                "member",
+                "public",
+                "team_add",
+                "status"
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "hookBody": {
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "add_events": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "issue": {
+      "properties": {
+        "assignee": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "milestone": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "issueBody": {
+      "properties": {
+        "assignee": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "milestone": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "issues": {
+      "items": {
+        "properties": {
+          "assignee": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "closed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "comments": {
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "labels": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "milestone": {
+            "properties": {
+              "closed_issues": {
+                "type": "integer"
+              },
+              "created_at": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "creator": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "description": {
+                "type": "string"
+              },
+              "due_on": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "number": {
+                "type": "integer"
+              },
+              "open_issues": {
+                "type": "integer"
+              },
+              "state": {
+                "enum": [
+                  "open",
+                  "closed"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "pull_request": {
+            "properties": {
+              "diff_url": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "patch_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "issuesComment": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "issuesComments": {
+      "items": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pull_request": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "commit_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "key": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "key": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "keyBody": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "keys": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "label": {
+      "properties": {
+        "color": {
+          "maxLength": 6,
+          "minLength": 6,
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "labels": {
+      "items": {
+        "properties": {
+          "color": {
+            "maxLength": 6,
+            "minLength": 6,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "labelsBody": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "languages": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "markdown": {
+      "properties": {
+        "context": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "members": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "merge": {
+      "properties": {
+        "merged": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergePullBody": {
+      "properties": {
+        "commit_message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergesBody": {
+      "properties": {
+        "base": {
+          "type": "string"
+        },
+        "commit_message": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergesConflict": {
+      "properties": {
+        "message": {
+          "description": "Error message",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mergesSuccessful": {
+      "properties": {
+        "author": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "events_url": {
+              "type": "string"
+            },
+            "followers_url": {
+              "type": "string"
+            },
+            "following_url": {
+              "type": "string"
+            },
+            "gists_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "organizations_url": {
+              "type": "string"
+            },
+            "received_events_url": {
+              "type": "string"
+            },
+            "repos_url": {
+              "type": "string"
+            },
+            "starred_url": {
+              "type": "string"
+            },
+            "subscriptions_url": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "comments_url": {
+          "type": "string"
+        },
+        "commit": {
+          "properties": {
+            "author": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "comment_count": {
+              "type": "integer"
+            },
+            "committer": {
+              "properties": {
+                "date": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "message": {
+              "type": "string"
+            },
+            "tree": {
+              "properties": {
+                "sha": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "committer": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "events_url": {
+              "type": "string"
+            },
+            "followers_url": {
+              "type": "string"
+            },
+            "following_url": {
+              "type": "string"
+            },
+            "gists_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "organizations_url": {
+              "type": "string"
+            },
+            "received_events_url": {
+              "type": "string"
+            },
+            "repos_url": {
+              "type": "string"
+            },
+            "starred_url": {
+              "type": "string"
+            },
+            "subscriptions_url": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "merged": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "meta": {
+      "properties": {
+        "git": {
+          "items": {
+            "description": "An Array of IP addresses in CIDR format specifying the Git servers at GitHub.",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "hooks": {
+          "items": {
+            "description": "An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.",
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "milestone": {
+      "properties": {
+        "closed_issues": {
+          "type": "integer"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "creator": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "number": {
+          "type": "integer"
+        },
+        "open_issues": {
+          "type": "integer"
+        },
+        "state": {
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "milestoneBody": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "milestoneUpdate": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "due_on": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "notificationMarkRead": {
+      "properties": {
+        "last_read_at": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "notifications": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "last_read_at": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "repository": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "fork": {
+              "type": "boolean"
+            },
+            "full_name": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "private": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject": {
+          "properties": {
+            "latest_comment_url": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "unread": {
+          "type": "boolean"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "orgMembers": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "orgPublicMembers": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "orgTeams": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "orgTeamsPost": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "permission": {
+          "enum": [
+            "pull",
+            "push",
+            "admin"
+          ]
+        },
+        "repo_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "organization": {
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "blog": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "followers": {
+          "type": "integer"
+        },
+        "following": {
+          "type": "integer"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "location": {
+          "type": "string"
+        },
+        "login": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "public_gists": {
+          "type": "integer"
+        },
+        "public_repos": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "organizationAsTeamMember": {
+      "properties": {
+        "errors": {
+          "items": {
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "field": {
+                "type": "string"
+              },
+              "resource": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "participationStats": {
+      "properties": {
+        "all": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "owner": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "patchGist": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "files": {
+          "properties": {
+            "delete_this_file.txt": {
+              "type": "string"
+            },
+            "file1.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "new_file.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "old_name.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "filename": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "patchOrg": {
+      "properties": {
+        "billing_email": {
+          "description": "Billing email address. This address is not publicized.",
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "email": {
+          "description": "Publicly visible email address.",
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "postComment": {
+      "properties": {
+        "body": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "type": "object"
+    },
+    "postGist": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "files": {
+          "properties": {
+            "file1.txt": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "public": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "postRepo": {
+      "properties": {
+        "auto_init": {
+          "description": "True to create an initial commit with empty README. Default is false.",
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "gitignore_template": {
+          "description": "Desired language or platform .gitignore template to apply. Use the name of the template without the extension. For example, \"Haskell\" Ignored if auto_init parameter is not provided. ",
+          "type": "string"
+        },
+        "has_downloads": {
+          "description": "True to enable downloads for this repository, false to disable them. Default is true.",
+          "type": "boolean"
+        },
+        "has_issues": {
+          "description": "True to enable issues for this repository, false to disable them. Default is true.",
+          "type": "boolean"
+        },
+        "has_wiki": {
+          "description": "True to enable the wiki for this repository, false to disable it. Default is true.",
+          "type": "boolean"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "private": {
+          "description": "True to create a private repository, false to create a public one. Creating private repositories requires a paid GitHub account.",
+          "type": "boolean"
+        },
+        "team_id": {
+          "description": "The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "pullRequest": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "comments": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "html": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "review_comments": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "self": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "additions": {
+          "type": "integer"
+        },
+        "base": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "repo": {
+              "properties": {
+                "clone_url": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "fork": {
+                  "type": "boolean"
+                },
+                "forks": {
+                  "type": "integer"
+                },
+                "forks_count": {
+                  "type": "integer"
+                },
+                "full_name": {
+                  "type": "string"
+                },
+                "git_url": {
+                  "type": "string"
+                },
+                "homepage": {
+                  "type": "string"
+                },
+                "html_url": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "language": {
+                  "type": "null"
+                },
+                "master_branch": {
+                  "type": "string"
+                },
+                "mirror_url": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "open_issues": {
+                  "type": "integer"
+                },
+                "open_issues_count": {
+                  "type": "integer"
+                },
+                "owner": {
+                  "properties": {
+                    "avatar_url": {
+                      "type": "string"
+                    },
+                    "gravatar_id": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "login": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "private": {
+                  "type": "boolean"
+                },
+                "pushed_at": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "ssh_url": {
+                  "type": "string"
+                },
+                "svn_url": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "watchers": {
+                  "type": "integer"
+                },
+                "watchers_count": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "user": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "changed_files": {
+          "type": "integer"
+        },
+        "closed_at": {
+          "type": "string"
+        },
+        "comments": {
+          "type": "integer"
+        },
+        "commits": {
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "deletions": {
+          "type": "integer"
+        },
+        "diff_url": {
+          "type": "string"
+        },
+        "head": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "repo": {
+              "properties": {
+                "clone_url": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "fork": {
+                  "type": "boolean"
+                },
+                "forks": {
+                  "type": "integer"
+                },
+                "forks_count": {
+                  "type": "integer"
+                },
+                "full_name": {
+                  "type": "string"
+                },
+                "git_url": {
+                  "type": "string"
+                },
+                "homepage": {
+                  "type": "string"
+                },
+                "html_url": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "language": {
+                  "type": "null"
+                },
+                "master_branch": {
+                  "type": "string"
+                },
+                "mirror_url": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "open_issues": {
+                  "type": "integer"
+                },
+                "open_issues_count": {
+                  "type": "integer"
+                },
+                "owner": {
+                  "properties": {
+                    "avatar_url": {
+                      "type": "string"
+                    },
+                    "gravatar_id": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "login": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "private": {
+                  "type": "boolean"
+                },
+                "pushed_at": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "ssh_url": {
+                  "type": "string"
+                },
+                "svn_url": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "watchers": {
+                  "type": "integer"
+                },
+                "watchers_count": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "sha": {
+              "type": "string"
+            },
+            "user": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "issue_url": {
+          "type": "string"
+        },
+        "merge_commit_sha": {
+          "type": "string"
+        },
+        "mergeable": {
+          "type": "boolean"
+        },
+        "merged": {
+          "type": "boolean"
+        },
+        "merged_at": {
+          "type": "string"
+        },
+        "merged_by": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "number": {
+          "type": "integer"
+        },
+        "patch_url": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "pullUpdate": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "pulls": {
+      "items": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "comments": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "review_comments": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "base": {
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "ref": {
+                "type": "string"
+              },
+              "repo": {
+                "properties": {
+                  "clone_url": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fork": {
+                    "type": "boolean"
+                  },
+                  "forks": {
+                    "type": "integer"
+                  },
+                  "forks_count": {
+                    "type": "integer"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "git_url": {
+                    "type": "string"
+                  },
+                  "homepage": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "language": {
+                    "type": "string"
+                  },
+                  "master_branch": {
+                    "type": "string"
+                  },
+                  "mirror_url": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "open_issues": {
+                    "type": "integer"
+                  },
+                  "open_issues_count": {
+                    "type": "integer"
+                  },
+                  "owner": {
+                    "properties": {
+                      "avatar_url": {
+                        "type": "string"
+                      },
+                      "gravatar_id": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "integer"
+                      },
+                      "login": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "private": {
+                    "type": "boolean"
+                  },
+                  "pushed_at": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "integer"
+                  },
+                  "ssh_url": {
+                    "type": "string"
+                  },
+                  "svn_url": {
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "watchers": {
+                    "type": "integer"
+                  },
+                  "watchers_count": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "closed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "diff_url": {
+            "type": "string"
+          },
+          "head": {
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "ref": {
+                "type": "string"
+              },
+              "repo": {
+                "properties": {
+                  "clone_url": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "fork": {
+                    "type": "boolean"
+                  },
+                  "forks": {
+                    "type": "integer"
+                  },
+                  "forks_count": {
+                    "type": "integer"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "git_url": {
+                    "type": "string"
+                  },
+                  "homepage": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "language": {
+                    "type": "string"
+                  },
+                  "master_branch": {
+                    "type": "string"
+                  },
+                  "mirror_url": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "open_issues": {
+                    "type": "integer"
+                  },
+                  "open_issues_count": {
+                    "type": "integer"
+                  },
+                  "owner": {
+                    "properties": {
+                      "avatar_url": {
+                        "type": "string"
+                      },
+                      "gravatar_id": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "integer"
+                      },
+                      "login": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "private": {
+                    "type": "boolean"
+                  },
+                  "pushed_at": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "integer"
+                  },
+                  "ssh_url": {
+                    "type": "string"
+                  },
+                  "svn_url": {
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "watchers": {
+                    "type": "integer"
+                  },
+                  "watchers_count": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "issue_url": {
+            "type": "string"
+          },
+          "merged_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "patch_url": {
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "pullsComment": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "html": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "pull_request": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "self": {
+              "properties": {
+                "href": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "pullsCommentPost": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "commit_id": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "position": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "pullsComments": {
+      "items": {
+        "properties": {
+          "_links": {
+            "properties": {
+              "html": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "pull_request": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "self": {
+                "properties": {
+                  "href": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "commit_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "pullsPost": {
+      "properties": {
+        "base": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "punchCardStats": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "putSubscription": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "ignored": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "object"
+        },
+        "subscribed": {
+          "type": "boolean"
+        },
+        "thread_url": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "rate_limit": {
+      "properties": {
+        "rate": {
+          "properties": {
+            "limit": {
+              "type": "integer"
+            },
+            "remaining": {
+              "type": "integer"
+            },
+            "reset": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "readme": {
+      "properties": {
+        "_links": {
+          "properties": {
+            "git": {
+              "type": "string"
+            },
+            "html": {
+              "type": "string"
+            },
+            "self": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "git_url": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ref": {
+      "items": {
+        "properties": {
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "creator": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string"
+          },
+          "target_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "refBody": {
+      "properties": {
+        "object": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "refStatus": {
+      "items": {
+        "properties": {
+          "commit_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "repository_url": {
+            "type": "string"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "statuses": {
+            "items": {
+              "properties": {
+                "context": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "number"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "target_url": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "refs": {
+      "items": {
+        "properties": {
+          "object": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "refsBody": {
+      "properties": {
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "release": {
+      "properties": {
+        "assets": {
+          "items": {
+            "properties": {
+              "content_type": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "download_count": {
+                "type": "integer"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "label": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "uploader": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "events_url": {
+                    "type": "string"
+                  },
+                  "followers_url": {
+                    "type": "string"
+                  },
+                  "following_url": {
+                    "type": "string"
+                  },
+                  "gists_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "organizations_url": {
+                    "type": "string"
+                  },
+                  "received_events_url": {
+                    "type": "string"
+                  },
+                  "repos_url": {
+                    "type": "string"
+                  },
+                  "site_admin": {
+                    "type": "boolean"
+                  },
+                  "starred_url": {
+                    "type": "string"
+                  },
+                  "subscriptions_url": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "assets_url": {
+          "type": "string"
+        },
+        "author": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "events_url": {
+              "type": "string"
+            },
+            "followers_url": {
+              "type": "string"
+            },
+            "following_url": {
+              "type": "string"
+            },
+            "gists_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "organizations_url": {
+              "type": "string"
+            },
+            "received_events_url": {
+              "type": "string"
+            },
+            "repos_url": {
+              "type": "string"
+            },
+            "site_admin": {
+              "type": "boolean"
+            },
+            "starred_url": {
+              "type": "string"
+            },
+            "subscriptions_url": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "body": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prerelease": {
+          "type": "boolean"
+        },
+        "published_at": {
+          "type": "string"
+        },
+        "tag_name": {
+          "type": "string"
+        },
+        "tarball_url": {
+          "type": "string"
+        },
+        "target_commitish": {
+          "type": "string"
+        },
+        "upload_url": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "zipball_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "release-create": {
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "draft": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prerelease": {
+          "type": "boolean"
+        },
+        "tag_name": {
+          "type": "string"
+        },
+        "target_commitish": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "releases": {
+      "items": {
+        "properties": {
+          "assets": {
+            "items": {
+              "properties": {
+                "content_type": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "download_count": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "uploader": {
+                  "properties": {
+                    "avatar_url": {
+                      "type": "string"
+                    },
+                    "events_url": {
+                      "type": "string"
+                    },
+                    "followers_url": {
+                      "type": "string"
+                    },
+                    "following_url": {
+                      "type": "string"
+                    },
+                    "gists_url": {
+                      "type": "string"
+                    },
+                    "gravatar_id": {
+                      "type": "string"
+                    },
+                    "html_url": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "login": {
+                      "type": "string"
+                    },
+                    "organizations_url": {
+                      "type": "string"
+                    },
+                    "received_events_url": {
+                      "type": "string"
+                    },
+                    "repos_url": {
+                      "type": "string"
+                    },
+                    "site_admin": {
+                      "type": "boolean"
+                    },
+                    "starred_url": {
+                      "type": "string"
+                    },
+                    "subscriptions_url": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "assets_url": {
+            "type": "string"
+          },
+          "author": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "events_url": {
+                "type": "string"
+              },
+              "followers_url": {
+                "type": "string"
+              },
+              "following_url": {
+                "type": "string"
+              },
+              "gists_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "organizations_url": {
+                "type": "string"
+              },
+              "received_events_url": {
+                "type": "string"
+              },
+              "repos_url": {
+                "type": "string"
+              },
+              "site_admin": {
+                "type": "boolean"
+              },
+              "starred_url": {
+                "type": "string"
+              },
+              "subscriptions_url": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prerelease": {
+            "type": "boolean"
+          },
+          "published_at": {
+            "type": "string"
+          },
+          "tag_name": {
+            "type": "string"
+          },
+          "tarball_url": {
+            "type": "string"
+          },
+          "target_commitish": {
+            "type": "string"
+          },
+          "upload_url": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "zipball_url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "repo": {
+      "properties": {
+        "clone_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fork": {
+          "type": "boolean"
+        },
+        "forks": {
+          "type": "integer"
+        },
+        "forks_count": {
+          "type": "integer"
+        },
+        "full_name": {
+          "type": "string"
+        },
+        "git_url": {
+          "type": "string"
+        },
+        "has_downloads": {
+          "type": "boolean"
+        },
+        "has_issues": {
+          "type": "boolean"
+        },
+        "has_wiki": {
+          "type": "boolean"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "language": {
+          "type": "string"
+        },
+        "master_branch": {
+          "type": "string"
+        },
+        "mirror_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "open_issues": {
+          "type": "integer"
+        },
+        "open_issues_count": {
+          "type": "integer"
+        },
+        "organization": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "owner": {
+          "properties": {
+            "avatar_url": {
+              "type": "string"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "login": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "parent": {
+          "description": "Is present when the repo is a fork. Parent is the repo this repo was forked from.",
+          "properties": {
+            "clone_url": {
+              "type": "string"
+            },
+            "created_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "fork": {
+              "type": "boolean"
+            },
+            "forks": {
+              "type": "integer"
+            },
+            "forks_count": {
+              "type": "integer"
+            },
+            "full_name": {
+              "type": "string"
+            },
+            "git_url": {
+              "type": "string"
+            },
+            "homepage": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "language": {
+              "type": "string"
+            },
+            "master_branch": {
+              "type": "string"
+            },
+            "mirror_url": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "open_issues": {
+              "type": "integer"
+            },
+            "open_issues_count": {
+              "type": "integer"
+            },
+            "owner": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "private": {
+              "type": "boolean"
+            },
+            "pushed_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "ssh_url": {
+              "type": "string"
+            },
+            "svn_url": {
+              "type": "string"
+            },
+            "updated_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "watchers": {
+              "type": "integer"
+            },
+            "watchers_count": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "private": {
+          "type": "boolean"
+        },
+        "pushed_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "source": {
+          "description": "Is present when the repo is a fork. Source is the ultimate source for the network.",
+          "properties": {
+            "clone_url": {
+              "type": "string"
+            },
+            "created_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "fork": {
+              "type": "boolean"
+            },
+            "forks": {
+              "type": "integer"
+            },
+            "forks_count": {
+              "type": "integer"
+            },
+            "full_name": {
+              "type": "string"
+            },
+            "git_url": {
+              "type": "string"
+            },
+            "homepage": {
+              "type": "string"
+            },
+            "html_url": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "language": {
+              "type": "string"
+            },
+            "master_branch": {
+              "type": "string"
+            },
+            "mirror_url": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "open_issues": {
+              "type": "integer"
+            },
+            "open_issues_count": {
+              "type": "integer"
+            },
+            "owner": {
+              "properties": {
+                "avatar_url": {
+                  "type": "string"
+                },
+                "gravatar_id": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "login": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "private": {
+              "type": "boolean"
+            },
+            "pushed_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "ssh_url": {
+              "type": "string"
+            },
+            "svn_url": {
+              "type": "string"
+            },
+            "updated_at": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "watchers": {
+              "type": "integer"
+            },
+            "watchers_count": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "ssh_url": {
+          "type": "string"
+        },
+        "svn_url": {
+          "type": "string"
+        },
+        "updated_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "watchers": {
+          "type": "integer"
+        },
+        "watchers_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "repo-deployments": {
+      "items": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "creator": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "events_url": {
+                "type": "string"
+              },
+              "followers_url": {
+                "type": "string"
+              },
+              "following_url": {
+                "type": "string"
+              },
+              "gists_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "organizations_url": {
+                "type": "string"
+              },
+              "received_events_url": {
+                "type": "string"
+              },
+              "repos_url": {
+                "type": "string"
+              },
+              "site_admin": {
+                "type": "boolean"
+              },
+              "starred_url": {
+                "type": "string"
+              },
+              "subscriptions_url": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "payload": {
+            "type": "string"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "statuses_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "repoComments": {
+      "items": {
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "commit_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "line": {
+            "type": "integer"
+          },
+          "path": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "repoCommit": {
+      "properties": {
+        "author": {
+          "properties": {
+            "date": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "committer": {
+          "properties": {
+            "date": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "properties": {
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "tree": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "repoCommitBody": {
+      "properties": {
+        "author": {
+          "properties": {
+            "date": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "message": {
+          "type": "string"
+        },
+        "parents": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tree": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "parents",
+        "tree"
+      ],
+      "type": "object"
+    },
+    "repoEdit": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "has_downloads": {
+          "type": "boolean"
+        },
+        "has_issues": {
+          "type": "boolean"
+        },
+        "has_wiki": {
+          "type": "boolean"
+        },
+        "homepage": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "repos": {
+      "items": {
+        "properties": {
+          "clone_url": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "fork": {
+            "type": "boolean"
+          },
+          "forks": {
+            "type": "integer"
+          },
+          "forks_count": {
+            "type": "integer"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "git_url": {
+            "type": "string"
+          },
+          "homepage": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "language": {
+            "type": "string"
+          },
+          "master_branch": {
+            "type": "string"
+          },
+          "mirror_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "open_issues": {
+            "type": "integer"
+          },
+          "open_issues_count": {
+            "type": "integer"
+          },
+          "owner": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "pushed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "ssh_url": {
+            "type": "string"
+          },
+          "svn_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "watchers": {
+            "type": "integer"
+          },
+          "watchers_count": {
+            "type": "integer"
+          }
+        }
+      },
+      "type": "array"
+    },
+    "repositories": {
+      "items": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "fork": {
+            "type": "boolean"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "search-code": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "git_url": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "repository": {
+                "properties": {
+                  "archive_url": {
+                    "type": "string"
+                  },
+                  "assignees_url": {
+                    "type": "string"
+                  },
+                  "blobs_url": {
+                    "type": "string"
+                  },
+                  "branches_url": {
+                    "type": "string"
+                  },
+                  "collaborators_url": {
+                    "type": "string"
+                  },
+                  "comments_url": {
+                    "type": "string"
+                  },
+                  "commits_url": {
+                    "type": "string"
+                  },
+                  "compare_url": {
+                    "type": "string"
+                  },
+                  "contents_url": {
+                    "type": "string"
+                  },
+                  "contributors_url": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "downloads_url": {
+                    "type": "string"
+                  },
+                  "events_url": {
+                    "type": "string"
+                  },
+                  "fork": {
+                    "type": "boolean"
+                  },
+                  "forks_url": {
+                    "type": "string"
+                  },
+                  "full_name": {
+                    "type": "string"
+                  },
+                  "git_commits_url": {
+                    "type": "string"
+                  },
+                  "git_refs_url": {
+                    "type": "string"
+                  },
+                  "git_tags_url": {
+                    "type": "string"
+                  },
+                  "hooks_url": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "issue_comment_url": {
+                    "type": "string"
+                  },
+                  "issue_events_url": {
+                    "type": "string"
+                  },
+                  "issues_url": {
+                    "type": "string"
+                  },
+                  "keys_url": {
+                    "type": "string"
+                  },
+                  "labels_url": {
+                    "type": "string"
+                  },
+                  "languages_url": {
+                    "type": "string"
+                  },
+                  "merges_url": {
+                    "type": "string"
+                  },
+                  "milestones_url": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "notifications_url": {
+                    "type": "string"
+                  },
+                  "owner": {
+                    "properties": {
+                      "avatar_url": {
+                        "type": "string"
+                      },
+                      "events_url": {
+                        "type": "string"
+                      },
+                      "followers_url": {
+                        "type": "string"
+                      },
+                      "following_url": {
+                        "type": "string"
+                      },
+                      "gists_url": {
+                        "type": "string"
+                      },
+                      "gravatar_id": {
+                        "type": "string"
+                      },
+                      "html_url": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "integer"
+                      },
+                      "login": {
+                        "type": "string"
+                      },
+                      "organizations_url": {
+                        "type": "string"
+                      },
+                      "received_events_url": {
+                        "type": "string"
+                      },
+                      "repos_url": {
+                        "type": "string"
+                      },
+                      "starred_url": {
+                        "type": "string"
+                      },
+                      "subscriptions_url": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "private": {
+                    "type": "boolean"
+                  },
+                  "pulls_url": {
+                    "type": "string"
+                  },
+                  "stargazers_url": {
+                    "type": "string"
+                  },
+                  "statuses_url": {
+                    "type": "string"
+                  },
+                  "subscribers_url": {
+                    "type": "string"
+                  },
+                  "subscription_url": {
+                    "type": "string"
+                  },
+                  "tags_url": {
+                    "type": "string"
+                  },
+                  "teams_url": {
+                    "type": "string"
+                  },
+                  "trees_url": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "score": {
+                "type": "number"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-issues": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "assignee": {
+                "type": "null"
+              },
+              "body": {
+                "type": "string"
+              },
+              "closed_at": {
+                "type": "null"
+              },
+              "comments": {
+                "type": "integer"
+              },
+              "comments_url": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "events_url": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "labels": {
+                "items": {
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "labels_url": {
+                "type": "string"
+              },
+              "milestone": {
+                "type": "null"
+              },
+              "number": {
+                "type": "integer"
+              },
+              "pull_request": {
+                "properties": {
+                  "diff_url": {
+                    "type": "null"
+                  },
+                  "html_url": {
+                    "type": "null"
+                  },
+                  "patch_url": {
+                    "type": "null"
+                  }
+                },
+                "type": "object"
+              },
+              "score": {
+                "type": "number"
+              },
+              "state": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "user": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "events_url": {
+                    "type": "string"
+                  },
+                  "followers_url": {
+                    "type": "string"
+                  },
+                  "following_url": {
+                    "type": "string"
+                  },
+                  "gists_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "organizations_url": {
+                    "type": "string"
+                  },
+                  "received_events_url": {
+                    "type": "string"
+                  },
+                  "repos_url": {
+                    "type": "string"
+                  },
+                  "starred_url": {
+                    "type": "string"
+                  },
+                  "subscriptions_url": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-issues-by-keyword": {
+      "properties": {
+        "issues": {
+          "items": {
+            "properties": {
+              "body": {
+                "type": "string"
+              },
+              "comments": {
+                "type": "integer"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "labels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "number": {
+                "type": "integer"
+              },
+              "position": {
+                "type": "integer"
+              },
+              "state": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "user": {
+                "type": "string"
+              },
+              "votes": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "search-repositories": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "created_at": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "default_branch": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "fork": {
+                "type": "boolean"
+              },
+              "forks": {
+                "type": "integer"
+              },
+              "forks_count": {
+                "type": "integer"
+              },
+              "full_name": {
+                "type": "string"
+              },
+              "homepage": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "language": {
+                "type": "string"
+              },
+              "master_branch": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "open_issues": {
+                "type": "integer"
+              },
+              "open_issues_count": {
+                "type": "integer"
+              },
+              "owner": {
+                "properties": {
+                  "avatar_url": {
+                    "type": "string"
+                  },
+                  "gravatar_id": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer"
+                  },
+                  "login": {
+                    "type": "string"
+                  },
+                  "received_events_url": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "private": {
+                "type": "boolean"
+              },
+              "pushed_at": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "updated_at": {
+                "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "watchers": {
+                "type": "integer"
+              },
+              "watchers_count": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-repositories-by-keyword": {
+      "properties": {
+        "repositories": {
+          "items": {
+            "properties": {
+              "created": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "followers": {
+                "type": "integer"
+              },
+              "fork": {
+                "type": "boolean"
+              },
+              "forks": {
+                "type": "integer"
+              },
+              "has_downloads": {
+                "type": "boolean"
+              },
+              "has_issues": {
+                "type": "boolean"
+              },
+              "has_wiki": {
+                "type": "boolean"
+              },
+              "homepage": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "open_issues": {
+                "type": "integer"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "private": {
+                "type": "boolean"
+              },
+              "pushed": {
+                "type": "string"
+              },
+              "pushed_at": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              },
+              "watchers": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "search-user-by-email": {
+      "properties": {
+        "user": {
+          "properties": {
+            "blog": {
+              "type": "string"
+            },
+            "company": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "followers_count": {
+              "type": "integer"
+            },
+            "following_count": {
+              "type": "integer"
+            },
+            "gravatar_id": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer"
+            },
+            "location": {
+              "type": "string"
+            },
+            "login": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "public_gist_count": {
+              "type": "integer"
+            },
+            "public_repo_count": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "search-users": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "followers_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "organizations_url": {
+                "type": "string"
+              },
+              "received_events_url": {
+                "type": "string"
+              },
+              "repos_url": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "subscriptions_url": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "search-users-by-keyword": {
+      "properties": {
+        "users": {
+          "items": {
+            "properties": {
+              "created": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "followers": {
+                "type": "integer"
+              },
+              "followers_count": {
+                "type": "integer"
+              },
+              "fullname": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "login": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "public_repo_count": {
+                "type": "integer"
+              },
+              "repos": {
+                "type": "integer"
+              },
+              "score": {
+                "type": "number"
+              },
+              "type": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "stargazers": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "subscribition": {
+      "properties": {
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "ignored": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "repository_url": {
+          "type": "string"
+        },
+        "subscribed": {
+          "type": "boolean"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "subscribitionBody": {
+      "properties": {
+        "ignored": {
+          "type": "boolean"
+        },
+        "subscribed": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "subscription": {
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "ignored": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "boolean"
+        },
+        "subscribed": {
+          "type": "boolean"
+        },
+        "thread_url": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tag": {
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "object": {
+          "properties": {
+            "sha": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "tagger": {
+          "properties": {
+            "date": {
+              "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tags": {
+      "properties": {
+        "message": {
+          "description": "String of the tag message.",
+          "type": "string"
+        },
+        "object": {
+          "description": "String of the SHA of the git object this is tagging.",
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "tagger": {
+          "properties": {
+            "date": {
+              "description": "Timestamp of when this object was tagged.",
+              "type": "string"
+            },
+            "email": {
+              "description": "String of the email of the author of the tag.",
+              "type": "string"
+            },
+            "name": {
+              "description": "String of the name of the author of the tag.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": {
+          "description": "String of the type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tag",
+        "message",
+        "object",
+        "type",
+        "tagger"
+      ],
+      "type": "object"
+    },
+    "team": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "members_count": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "permission": {
+          "type": "string"
+        },
+        "repos_count": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "teamMembership": {
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "teamRepos": {
+      "items": {
+        "properties": {
+          "clone_url": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "fork": {
+            "type": "boolean"
+          },
+          "forks": {
+            "type": "integer"
+          },
+          "forks_count": {
+            "type": "integer"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "git_url": {
+            "type": "string"
+          },
+          "homepage": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "language": {
+            "type": "null"
+          },
+          "master_branch": {
+            "type": "string"
+          },
+          "mirror_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "open_issues": {
+            "type": "integer"
+          },
+          "open_issues_count": {
+            "type": "integer"
+          },
+          "owner": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "pushed_at": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "ssh_url": {
+            "type": "string"
+          },
+          "svn_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "watchers": {
+            "type": "integer"
+          },
+          "watchers_count": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "teams": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "teams-list": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "members_count": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "organization": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "permission": {
+            "type": "string"
+          },
+          "repos_count": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "tree": {
+      "properties": {
+        "sha": {
+          "type": "string"
+        },
+        "tree": {
+          "items": {
+            "properties": {
+              "mode": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "trees": {
+      "properties": {
+        "base_tree": {
+          "type": "string"
+        },
+        "sha": {
+          "description": "SHA1 checksum ID of the object in the tree.",
+          "type": "string"
+        },
+        "tree": {
+          "items": {
+            "properties": {
+              "mode": {
+                "description": "One of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree), 160000 for submodule (commit) or 120000 for a blob that specifies the path of a symlink.",
+                "enum": [
+                  "100644",
+                  "100755",
+                  "040000",
+                  "160000",
+                  "120000"
+                ],
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "sha": {
+                "description": "SHA1 checksum ID of the object in the tree.",
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "blob",
+                  "tree",
+                  "commit"
+                ],
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user": {
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "bio": {
+          "type": "string"
+        },
+        "blog": {
+          "type": "string"
+        },
+        "collaborators": {
+          "type": "integer"
+        },
+        "company": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "disk_usage": {
+          "type": "integer"
+        },
+        "email": {
+          "type": "string"
+        },
+        "followers": {
+          "type": "integer"
+        },
+        "following": {
+          "type": "integer"
+        },
+        "gravatar_id": {
+          "type": "string"
+        },
+        "hireable": {
+          "type": "boolean"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "location": {
+          "type": "string"
+        },
+        "login": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "owned_private_repos": {
+          "type": "integer"
+        },
+        "plan": {
+          "properties": {
+            "collaborators": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "private_repos": {
+              "type": "integer"
+            },
+            "space": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "private_gists": {
+          "type": "integer"
+        },
+        "public_gists": {
+          "type": "integer"
+        },
+        "public_repos": {
+          "type": "integer"
+        },
+        "total_private_repos": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "user-emails_final": {
+      "items": {},
+      "type": "array"
+    },
+    "user-keys": {
+      "items": {},
+      "type": "array"
+    },
+    "user-keys-keyId": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "key": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-keys-post": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-update": {
+      "properties": {
+        "bio": {
+          "type": "string"
+        },
+        "blog": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "hireable": {
+          "type": "boolean"
+        },
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-userId": {
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "bio": {
+          "type": "string"
+        },
+        "blog": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "created_at": {
+          "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+          "type": "string"
+        },
+        "email": {
+          "description": "Note: The returned email is the user’s publicly visible email address (or null if the user has not specified a public email address in their profile).",
+          "type": "string"
+        },
+        "followers": {
+          "type": "integer"
+        },
+        "following": {
+          "type": "integer"
+        },
+        "gravatar_id": {
+          "type": "string"
+        },
+        "hireable": {
+          "type": "boolean"
+        },
+        "html_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "location": {
+          "type": "string"
+        },
+        "login": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "public_gists": {
+          "type": "integer"
+        },
+        "public_repos": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "user-userId-starred": {
+      "items": {},
+      "type": "array"
+    },
+    "user-userId-subscribitions": {
+      "items": {
+        "properties": {
+          "clone_url": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "fork": {
+            "type": "boolean"
+          },
+          "forks": {
+            "type": "integer"
+          },
+          "forks_count": {
+            "type": "integer"
+          },
+          "full_name": {
+            "type": "string"
+          },
+          "git_url": {
+            "type": "string"
+          },
+          "homepage": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "language": {
+            "type": "string"
+          },
+          "master_branch": {
+            "type": "integer"
+          },
+          "mirror_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "open_issues": {
+            "type": "integer"
+          },
+          "open_issues_count": {
+            "type": "integer"
+          },
+          "owner": {
+            "properties": {
+              "avatar_url": {
+                "type": "string"
+              },
+              "gravatar_id": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "login": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "pushed_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "ssh_url": {
+            "type": "string"
+          },
+          "svn_url": {
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ",
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "watchers": {
+            "type": "integer"
+          },
+          "watchers_count": {
+            "type": "integer"
+          }
+        }
+      },
+      "type": "array"
+    },
+    "users": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "gravatar_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "login": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "users-userId-keys": {
+      "items": {},
+      "type": "array"
+    },
+    "users-userId-orgs": {
+      "items": {},
+      "type": "array"
+    }
+  }
+}

--- a/hubs/swagger/mealcanteen.json
+++ b/hubs/swagger/mealcanteen.json
@@ -1,0 +1,275 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "mealcanteen"
+  },
+  "host": "mealcanteen.com",
+  "basePath": "/api",
+  "paths": {
+    "/upcoming": {
+      "get": {
+        "summary": "Fetch upcoming",
+        "responses": {
+          "200": {
+            "schema": null
+          },
+          "description": "OK"
+        }
+      }
+    },
+    "/orders/{order_id}/ratings": {
+      "post": {
+        "summary": "Create rating",
+        "responses": {
+          "201": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "score": {
+                  "type": "integer"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "description": "Created"
+        },
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "url",
+            "required": true,
+            "type": "integer",
+            "description": "Id of the order object to rate"
+          },
+          {
+            "name": "rating.score",
+            "in": "body",
+            "required": true,
+            "type": "integer",
+            "description": "Rating value for the given order"
+          }
+        ]
+      }
+    },
+    "/orders/{order_id}/ratings/{id}": {
+      "patch": {
+        "summary": "Update rating",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "score": {
+                  "type": "integer"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "description": "OK"
+        }
+      },
+      "put": {
+        "summary": "Update rating",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "score": {
+                  "type": "integer"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "description": "OK"
+        }
+      }
+    },
+    "/orders": {
+      "get": {
+        "summary": "List all orders",
+        "responses": {
+          "200": {
+            "schema": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "can_be_rated_from": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "can_be_destroyed_until": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lunch": {
+                    "$ref": "lunch"
+                  },
+                  "order_items": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "order_item"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "description": "OK"
+        }
+      },
+      "post": {
+        "summary": "Create order",
+        "responses": {
+          "201": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "can_be_rated_from": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "can_be_destroyed_until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "lunch": {
+                  "type": "string",
+                  "description": "this is lunch property",
+                  "example": "chicken 🐔 🍗"
+                },
+                "order_items": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "order_item"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Created"
+        }
+      }
+    },
+    "/orders/{id}": {
+      "delete": {
+        "summary": "Destroy order",
+        "responses": null
+      }
+    },
+    "/user": {
+      "get": {
+        "summary": "Fetch user",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "first_name": {
+                  "type": "string"
+                },
+                "last_name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "devices": {
+                  "type": "array"
+                },
+                "balance": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "organization": {
+                  "$ref": "organization"
+                }
+              }
+            }
+          },
+          "description": "OK"
+        }
+      }
+    },
+    "/devices": {
+      "post": {
+        "summary": "Create device",
+        "responses": {
+          "201": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "onesignal_uuid": {
+                  "type": "string"
+                },
+                "user_id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "description": "Created"
+        }
+      }
+    },
+    "/charges": {
+      "post": {
+        "summary": "Create charge",
+        "responses": {
+          "201": {
+            "schema": null
+          },
+          "description": "Created"
+        }
+      }
+    }
+  }
+}

--- a/hubs/swagger/petstore.json
+++ b/hubs/swagger/petstore.json
@@ -1,0 +1,222 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "findPets",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "findPetById",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "ErrorModel": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/hubs/swagger/stack-level-too-deep.json
+++ b/hubs/swagger/stack-level-too-deep.json
@@ -1,0 +1,12 @@
+{
+  "WorkflowItem": {
+    "properties": {
+      "conditions": {
+        "$ref": "#/Condition"
+      }
+    }
+  },
+  "Condition": {
+    "$ref": "#/WorkflowItem"
+  },
+}

--- a/hubs/swagger/twilio.json
+++ b/hubs/swagger/twilio.json
@@ -1,0 +1,10490 @@
+{
+  "swagger": "2.0",
+  "schemes": [
+    "https"
+  ],
+  "host": "api.twilio.com",
+  "basePath": "/2010-04-01",
+  "info": {
+    "description": "Enabling phones, VoIP, and messaging to be embedded into web, desktop, and mobile software.\n",
+    "title": "Twilio",
+    "version": "2010-04-01",
+    "x-apisguru-categories": [
+      "telecom",
+      "messaging"
+    ],
+    "x-logo": {
+      "url": "https://api.apis.guru/v2/cache/logo/https_static1.twilio.com_marketing_bundles_marketing_img_logos_wordmark-red.svg"
+    },
+    "x-origin": [
+      {
+        "format": "swagger",
+        "url": "https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/twilio.com/2010-04-01/swagger.yaml",
+        "version": "2.0"
+      }
+    ],
+    "x-preferred": true,
+    "x-providerName": "twilio.com",
+    "x-unofficialSpec": true
+  },
+  "externalDocs": {
+    "url": "https://www.twilio.com/api"
+  },
+  "securityDefinitions": {
+    "basic": {
+      "type": "basic"
+    }
+  },
+  "paths": {
+    "/Accounts/{AccountSid}/Applications/{ApplicationSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Delete this application.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ApplicationSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Application deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get application instance resource.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ApplicationSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/application"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Tries to update the application's properties, and returns the updated\nresource representation if successful. The returned response is identical\nto that returned above when making a GET request.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ApplicationSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/application"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Applications{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of Application resource representations, each representing\nan application within your account. The list includes paging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/applications"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Creates a new application within your account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/application"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/AuthorizedConnectApps/{ConnectAppSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Get the properties of the authorized application.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConnectAppSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/authApp"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/AuthorizedConnectApps{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of Connect App resource representations, each representing a\nConnect App you've authorized to access your account. The list includes\npaging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/authApps"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/AvailablePhoneNumbers/{IsoCountryCode}/Local{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of local AvailablePhoneNumber resource representations\nthat match the specified filters, each representing a phone number tha\nis currently available for provisioning within your account.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ISO 3166-1 alpha-2.",
+            "in": "path",
+            "maxLength": 2,
+            "minLength": 2,
+            "name": "IsoCountryCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/availablePhoneNumbers"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/AvailablePhoneNumbers/{IsoCountryCode}/Mobile{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of mobile AvailablePhoneNumber resource representations that match the specified filters, each representing a phone number that is currently available for provisioning within your account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ISO 3166-1 alpha-2.",
+            "in": "path",
+            "maxLength": 2,
+            "minLength": 2,
+            "name": "IsoCountryCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/phoneMobileNumbers"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/AvailablePhoneNumbers/{IsoCountryCode}/TollFree{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of toll-free AvailablePhoneNumber elements that match the\nspecified filters, each representing a phone number that is currently\navailable for provisioning within your account. To provision an available\nphone number, POST the number to the IncomingPhoneNumbers resource.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "ISO 3166-1 alpha-2.",
+            "in": "path",
+            "maxLength": 2,
+            "minLength": 2,
+            "name": "IsoCountryCode",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/phoneTollFreeNumbers"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/AvailablePhoneNumbers{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of all AvailablePhoneNumber subresources for your account by ISO Country. For full information about our phone number support, see our Phone Number CSV (http://www.twilio.com/resources/rates/international-phone-number-rates.csv).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/availablePhoneNumbers"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Calls/{CallSid}/Notifications{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of notifications generated for an account. The list includes\npaging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Calls/{CallSid}/Recordings{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of Recording resource representations, each representing a\nrecording generated during the course of a phone call.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/recordings"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Calls/{CallSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns the single Call resource identified by {CallSid}.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/callInstance"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Modify a phone call.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/callInstance"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Calls{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of phone calls made to and from the account identified by {AccountSid}.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/calls"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "To make a call, make an HTTP POST request. Initiate a new phone call.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/call"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Conferences/{ConferenceSid}/Participants/{CallSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Kick this participant from the conference.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConferenceSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Participant was successfully booted from the conference."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Returns a representation of this participant.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConferenceSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/participant"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Updates the status of a participant.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConferenceSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/participant"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Conferences/{ConferenceSid}/Participants{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns the list of participants in the conference identified by\n{ConferenceSid}.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConferenceSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/participants"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Conferences/{ConferenceSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a representation of the conference identified by {ConferenceSid}.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConferenceSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/conference"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Conferences{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of conferences within an account. The list includes paging\ninformation.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/conferences"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/ConnectApps/{ConnectAppSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Get the properties of a Connect App.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConnectAppSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/connectApp"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Tries to update the Connect App's properties, and returns the updated\nresource representation if successful. The returned response is identical\nto that returned above when making a GET request.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ConnectAppSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/connectApp"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/ConnectApps{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of Connect App resource representations, each representing\na Connect App in your account. The list includes paging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/connectApps"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/IncomingPhoneNumbers/Local{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of local <IncomingPhoneNumber> elements, each representing a local (not toll-free) phone number given to your account, under an <IncomingPhoneNumbers> list element that includes paging information. Works exactly the same as the IncomingPhoneNumber resource, but filters out toll-free numbers.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Adds a new phone number to your account. If a phone number is found for your request, Twilio will add it to your account and bill you for the first month's cost of the phone number. ",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "If Twilio can't find a phone number to match your request, you will receive an HTTP 400 with Twilio error code 21452."
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/IncomingPhoneNumbers/Mobile{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of local <IncomingPhoneNumber> elements, each representing a mobile phone number given to your account, under an <IncomingPhoneNumbers> list element that includes paging information. Works exactly the same as the IncomingPhoneNumber resource, but filters out local and toll free numbers.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Adds a new phone number to your account. If a phone number is found for your request, Twilio will add it to your account and bill you for the first month's cost of the phone number.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "If Twilio can't find a phone number to match your request, you will receive an HTTP 400 with Twilio error code 21452."
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/IncomingPhoneNumbers/TollFree{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of local <IncomingPhoneNumber> elements, each representing a toll-free phone number given to your account, under an <IncomingPhoneNumbers> list element that includes paging information. Works exactly the same as the IncomingPhoneNumber resource, but filters out all numbers that aren't toll-free.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Adds a new phone number to your account. If a phone number is found for your request, Twilio will add it to your account and bill you for the first month's cost of the phone number. ",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "If Twilio can't find a phone number to match your request, you will receive an HTTP 400 with Twilio error code 21452."
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/IncomingPhoneNumbers/{IncomingPhoneNumberSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Release this phone number from your account. Twilio will no longer answer\ncalls to this number, and you will stop being billed the monthly phone\nnumber fee. The phone number will eventually be recycled and potentially\ngiven to another customer, so use with care. If you make a mistake, contac\nus. We may be able to give you the number back.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IncomingPhoneNumberSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Phone number removed."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get info about incoming call's phone number.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IncomingPhoneNumberSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/incomingCall"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Tries to update the incoming phone number's properties, and returns the\nupdated resource representation if successful. The returned response is\nidentical to that returned above when making a GET request.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IncomingPhoneNumberSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/incomingCall"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Tries to update the incoming phone number's properties, and returns the\nupdated resource representation if successful. The returned response is\nidentical to that returned above when making a GET request.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IncomingPhoneNumberSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/incomingCall"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/IncomingPhoneNumbers{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of IncomingPhoneNumber resource representations, each\nrepresenting a phone number given to your account. The list includes paging\ninformation.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/incomingCalls"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Purchases a new phone number for your account. If a phone number is found\nfor your request, Twilio will add it to your account and bill you for the\nfirst month's cost of the phone number.\nTo find an available phone number to POST, use the subresources of the\nAvailablePhoneNumbers list resource.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/incomingCall"
+            }
+          },
+          "400": {
+            "description": "If Twilio cannot find a phone number to match your request, you will receive an HTTP 400 with Twilio error code 21452."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Messages/{MessageSid}/Media/{MediaSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Without an extension, the media is returned using the mime-type provided when the media was generated.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "MessageSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "MediaSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/media"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Messages/{MessageSid}/Media{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of media associated with your message.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "MessageSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/mediaList"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Messages/{MessageSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a single message specified by the provided {MessageSid}.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "MessageSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/message"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Messages{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of messages associated with your account. The list includes paging information.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/messages"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "To send a new outgoing message, make an HTTP POST to your Messages list resource URI",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The destination phone number. Format with a '+' and country code e.g., +16175551212 (E.164 format).\n",
+            "in": "formData",
+            "name": "To",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "A Twilio phone number (in E.164 format) or alphanumeric sender ID enabled for the type of message you wish to send. Phone numbers or short codes purchased from Twilio work here. You cannot (for example) spoof messages from your own cell phone number.\n",
+            "in": "formData",
+            "name": "From",
+            "type": "string"
+          },
+          {
+            "description": "The 34 character unique id of the Messaging Service you want to associate with this Message. Set this parameter to use the Messaging Service Settings and Copilot Features you have configured. When only this parameter is set, Twilio will use your enabled Copilot Features to select the From phone number for delivery.\n",
+            "in": "formData",
+            "name": "MessagingServiceSid",
+            "type": "string"
+          },
+          {
+            "description": "The text of the message you want to send, limited to 1600 characters.\n",
+            "in": "formData",
+            "name": "Body",
+            "type": "string"
+          },
+          {
+            "description": "The URL of the media you wish to send out with the message. gif , png and jpeg content is currently supported and will be formatted correctly on the recipient's device. Other types are also accepted by the API. The media size limit is 5MB. If you wish to send more than one image in the message body, please provide multiple MediaUrls values in the POST request. You may include up to 10 MediaUrls per message.\n",
+            "in": "formData",
+            "name": "MediaUrl",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/message"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Notifications/{NotificationSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Deletes the notification identified by {NotificationSid} from an account's log.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "NotificationSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Notification removed."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get a notification entry.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "NotificationSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/notification"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Notifications{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of notifications generated for an account. The list includes\npaging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/notifications"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/OutgoingCallerIds/{OutgoingCallerIdSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Deletes the caller ID from the account. Returns an HTTP 204 response if\nsuccessful, with no body.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "OutgoingCallerIdSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deletion successful."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get the set of an account's verified phone numbers.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "OutgoingCallerIdSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/outgoingCallerId"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Updates the caller id, and returns the updated resource if successful.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "OutgoingCallerIdSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/outgoingCallerId"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Updates the caller id, and returns the updated resource if successful.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "OutgoingCallerIdSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/OutgoingCallerIds{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of OutgoingCallerId resource representations, each representing\na Caller ID number valid for an account. The list includes paging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/outCallerIds"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Adds a new CallerID to your account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/outCaller"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Queues/{QueueSid}/Members/Front{mediaTypeExtension}": {
+      "get": {
+        "description": "Get a front member.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/member"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Posting a URL and Method to a Queue instance will dequeue a member from a\nqueue and have the member's call begin executing the TwiML document at that URL\nWhen dequeuing the 'Front' of the queue, the next call in the queue will be redirected.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/member"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "Member was already dequed."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Queues/{QueueSid}/Members/{CallSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Get a specific member.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/member"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Posting a URL and Method to a Queue instance will dequeue a member from a\nqueue and have the member's call begin executing the TwiML document at that URL\nWhen redirecting a member of a queue addressed by CallSid, only the first request\nwill succeed and return a 200 response code. A second request will fail and\nreturn an appropriate 400 response code.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CallSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/member"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "Member was already dequed."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Queues/{QueueSid}/Members{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns the list of members in the queue identified by {QueueSid}.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/members"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Queues/{QueueSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "The DELETE method allows you to remove a Queue. Only empty queues are\ndeletable.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Queue removed."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get resource's individual Queue instance.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/queue"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "This POST request allows you to change the FriendlyName or MaxSize.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "QueueSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/queue"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Queues{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a list of queues within an account. The list includes paging\ninformation.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/queues"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Create a new Queue resource.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/queue"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Recordings/{RecordingSid}/Transcriptions{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a set of Transcription resource representations that includes paging\ninformation.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "RecordingSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/transcriptions"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Recordings/{RecordingSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Deletes a recording  from your account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": ".wav",
+            "description": "",
+            "enum": [
+              ".xml",
+              ".wav",
+              ".mp3"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "RecordingSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deletion successful."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Returns one of several representations:\nWithout an extension, or with a \".wav\", a binary WAV audio file is returned\nwith mime-type \"audio/x-wav\".\nAppending \".mp3\" to the URI returns a binary MP3 audio file with mime-type\ntype \"audio/mpeg\".\nAppending \".xml\" to the URI returns a XML representation.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": ".wav",
+            "description": "",
+            "enum": [
+              ".xml",
+              ".wav",
+              ".mp3"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "RecordingSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "audio/x-wav",
+          "application/xml",
+          "audio/mpeg"
+        ],
+        "responses": {
+          "200": {
+            "description": "A binary WAV audio file is returned."
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Recordings{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of Recording resource representations, each representing a\nrecording generated during the course of a phone call.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/recordings"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/CredentialLists/{CLSid}/Credentials/{CredentialSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Remove a Credential from a CredentialList.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CredentialSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get a specific Credential in a list. Though a password is stored for each username in your list, the password is not returned to protect your password. If you cannot remember your password, you will need to POST to this resource to update it.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CredentialSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/credential"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Change the password of a Credential record.\n\nIf the change is successful, Twilio will respond with the Credential record but will not include the password in the response.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CredentialSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/credential"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/CredentialLists/{CLSid}/Credentials{mediaTypeExtension}": {
+      "get": {
+        "description": "Get the list of Credentials in a CredentialList. The passwords for the Credentials are intentionally not returned so as to protect them.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/credentials"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Add a Credential to the CredentialList.\n\nWhen creating a Credential, you will POST both a username and password, but only receive the username back in the response. The password is intentionally not returned so as to protect it.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/credential"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/CredentialLists/{CLSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Delete a CredentialList from your account. It can only be deleted if no domains are mapped to it. If you attempt to delete one that is mapped to a domain, you will receive an error.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Get a credential list instance resource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/credentialList"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Change the FriendlyName of the list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/credentialList"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/CredentialLists{mediaTypeExtension}": {
+      "get": {
+        "description": "Gets a list of Credential Lists for an account",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/credentialLists"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Create a new Credential List.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/credentialList"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/Domains/{SipDomainSid}/CredentialListMappings/{CLSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Remove a CredentialListMapping from a domain",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "CLSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/Domains/{SipDomainSid}/CredentialListMappings{mediaTypeExtension}": {
+      "get": {
+        "description": "Get the user lists mapped to this domain.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/credentialListMappings"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Map a CredentialList to the domain.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/credentialListMapping"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/Domains/{SipDomainSid}/IpAccessControlListMappings/{ALSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Remove a mapping from this domain.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ALSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Return a specific IpAccessControlListMapping instance by Sid.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ALSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAccessControlListMapping"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/Domains/{SipDomainSid}/IpAccessControlListMappings{mediaTypeExtension}": {
+      "get": {
+        "description": "Return the IpAccessControlListMappings that are associated to this domain.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Map an IpAccessControlList to this domain.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/Domains/{SipDomainSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Delete a domain. If you have created subdomains of a domain, you will not be able to delete the domain until you first delete all subdomains of it.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Return a specific instance by Sid.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/domain"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "description": "Update the attributes of a domain.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "SipDomainSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/domain"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/Domains{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a paged list of the domains for an account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/domains"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Creates a new Domain and returns its instance resource. You must pick a unique domain name that ends in \".sip.twilio.com\".\nAfter creating a Domain, you must map it to an authentication method before the domain is ready to receive traffic.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/domain"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/IpAccessControlLists/{IpAccessControlListSid}/IpAddresses/{IpAddressSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Deletes an IP address entry from the list.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAddressSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Return a single IP Address resource.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAddressSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAddress"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Change the description or IP address of a given IpAddress instance resource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAddressSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAddress"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/IpAccessControlLists/{IpAccessControlListSid}/IpAddresses{mediaTypeExtension}": {
+      "get": {
+        "description": "List the IP Addresses contained in this list.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAddresses"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Add an IP Address to the list with a description.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAddress"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/IpAccessControlLists/{IpAccessControlListSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Delete an IpAccessControlList from your account. It can only be deleted if no domains are mapped to it. If you attempt to delete one that is mapped to a domain, you will receive an error.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The request was successful; the resource was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Return a specific IpAccessControlList resource.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAccessControlListMapping"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Rename an IpAccessControlList.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "IpAccessControlListSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/ipAccessControlListMapping"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SIP/IpAccessControlLists{mediaTypeExtension}": {
+      "get": {
+        "description": "Return a paged list of all IpAccessControlLists under this account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Create a new IpAccessControlList resource.\n\nWhen created, the list will contain no IP addresses. You will need to add IP addresses to the list for it to be active. To add IP addresses, you will need to POST to the IpAddresses List subresource.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ipAccessControlListMapping"
+            }
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SMS/ShortCodes/{ShortCodeSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Get a single message.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ShortCodeSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/shortCode"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Tries to update the shortcode's properties, and returns the updated\nresource representation if successful.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "ShortCodeSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/shortCode"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/SMS/ShortCodes{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of ShortCode resource representations, each representing a\nshort code within your account. The list includes paging information.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/shortCodes"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Transcriptions/{TranscriptionSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Deletes a transcription from your account.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": ".xml",
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html",
+              ".txt",
+              ".xml"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "TranscriptionSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deletion successful."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Returns a single Transcription resource representation identified by the\ngiven {TranscriptionSid}. By default Twilio will respond with the XML metadata for the Transcription. If you append \".txt\" to the end of the Transcription resource's URI Twilio will just return you the transcription tex.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "default": ".xml",
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html",
+              ".txt",
+              ".xml"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "TranscriptionSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml",
+          "application/text"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/transcription"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Transcriptions{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a set of Transcription resource representations that includes paging\ninformation.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/transcriptions"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Usage/Records/{Subresource}{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns UsageRecords for all usage categories for a specified period.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "|Subresource|Description|\n|---|---|\n|Daily|Return multiple UsageRecords for each usage category, each representing usage over a daily time-interval.|\n|Monthly|Return multiple UsageRecords for each usage category, each representing usage over a monthly time-interval.|\n|Yearly|Return multple UsageRecords for each usage category, each representing usage over a yearly time-interval.|\n|AllTime|  Return a single UsageRecord for each usage category, each representing usage over the date-range specified. This is the same as the root /Usage/Records.|\n|Today|Return a single UsageRecord per usage category, for today's usage only.|\n||Yesterday|Return a single UsageRecord per usage category, for yesterday's usage only.|\n|ThisMonth|Return a single UsageRecord per usage category, for this month's usage only.|\n|LastMonth|Return a single UsageRecord per usage category, for last month's usage only.|\n",
+            "enum": [
+              "Daily",
+              "Monthly",
+              "Yearly",
+              "AllTime",
+              "Today",
+              "Yesterday",
+              "ThisMonth",
+              "LastMonth"
+            ],
+            "in": "path",
+            "name": "Subresource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/usageRecords"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Usage/Records{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns UsageRecords for all usage categories. The list includes paging\ninformation.\nBy default, the UsageRecords resource will return one UsageRecord for\neach Category, representing all usage accrued all-time for the account.\nYou can filter the usage Category or change the date-range over which usage\nis counted using optional GET query parameters.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/usageRecords"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Usage/Triggers/{UsageTriggerSid}{mediaTypeExtension}": {
+      "delete": {
+        "description": "Delete this UsageTrigger.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "UsageTriggerSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "UsageTrigger was deleted."
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to delete the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't DELETE the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't delete the resource. Please try again."
+          }
+        }
+      },
+      "get": {
+        "description": "Returns a repesentation of the UsageTrigger.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "UsageTriggerSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/usageTrigger"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Tries to update the UsageTrigger's properties, and returns the updated\nresource representation if successful.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "UsageTriggerSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/usageTrigger"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}/Usage/Triggers{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Returns a list of UsageTrigger resource representations. The list includes\npaging information.\nBy default, all UsageTriggers are returned. You can filter the list by\nspecifying one or more query parameters. Note that the query parameters are\ncase-sensitive\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/usageTriggers"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Creates a new UsageTrigger. Each account can create up to 1,000 UsageTriggers.\nCurrently, UsageTriggers that are no longer active are not deleted automatically.\nUse DELETE to delete triggers you no longer need.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/usageTrigger"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts/{AccountSid}{mediaTypeExtension}": {
+      "get": {
+        "description": "Returns a representation of an account.",
+        "parameters": [
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "A 34 character string that uniquely identifies this account.",
+            "in": "path",
+            "maxLength": 34,
+            "minLength": 34,
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/account"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Allows you to modify the properties of an account.",
+        "parameters": [
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "A 34 character string that uniquely identifies this account.",
+            "in": "path",
+            "maxLength": 34,
+            "minLength": 34,
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/account"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Allows you to modify the properties of an account.",
+        "parameters": [
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "A 34 character string that uniquely identifies this account.",
+            "in": "path",
+            "maxLength": 34,
+            "minLength": 34,
+            "name": "AccountSid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/account"
+            }
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n"
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    },
+    "/Accounts{mediaTypeExtension}": {
+      "get": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Retrieve a list of the Account resources belonging to the account used to make the\nAPI request. This list will include that Account as well.\n",
+        "parameters": [
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful and the response body contains the representation\nrequested.\n",
+            "schema": {
+              "$ref": "#/definitions/accounts"
+            }
+          },
+          "302": {
+            "description": "A common redirect response; you can GET the representation at the URI\nin the Location response header.\n"
+          },
+          "304": {
+            "description": "Your client's cached version of the representation is still up to date.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to access the resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          },
+          "503": {
+            "description": "We are temporarily unable to return the representation. Please wait for\na bit and try again.\n"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "description": "Create a new Account instance resource as a subaccount of the one used to make the request. See\nCreating Subaccounts for more information.\n",
+        "parameters": [
+          {
+            "description": "By default, Twilio's REST API returns XML. You may obtain CSV, JSON or HTML by appending \".csv\", \".json\", or \".html\".\n",
+            "enum": [
+              ".json",
+              ".csv",
+              ".html"
+            ],
+            "in": "path",
+            "name": "mediaTypeExtension",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request was successful, we updated the resource and the response\nbody contains the representation.\n"
+          },
+          "201": {
+            "description": "The request was successful, we created a new resource and the response\nbody contains the representation.\n",
+            "schema": {
+              "$ref": "#/definitions/account"
+            }
+          },
+          "400": {
+            "description": "The data given in the POST or PUT failed validation. Inspect the response\nbody for details.\n"
+          },
+          "401": {
+            "description": "The supplied credentials, if any, are not sufficient to create or update\nthe resource.\n"
+          },
+          "404": {
+            "description": "NOT FOUND."
+          },
+          "405": {
+            "description": "You can't POST or PUT to the resource."
+          },
+          "429": {
+            "description": "Your application is sending too many simultaneous requests."
+          },
+          "500": {
+            "description": "We couldn't return the representation due to an internal server error.\n"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "account": {
+      "properties": {
+        "auth_token": {
+          "type": "string"
+        },
+        "date_created": {
+          "description": "The date that this account was created, in GMT in RFC 2822 format",
+          "type": "string"
+        },
+        "date_updated": {
+          "description": "The date that this account was last updated, in GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "friendly_name": {
+          "description": "A human readable description of this account, up to 64 characters long. By default the FriendlyName is your email address.",
+          "type": "string"
+        },
+        "sid": {
+          "description": "A 34 character string that uniquely identifies this account.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of this account. Usually active, but can be suspended or closed.",
+          "type": "string"
+        },
+        "subresource_uris": {
+          "type": "object"
+        },
+        "type": {
+          "description": "The type of this account. Either Trial or Full if you've upgraded.",
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "accounts": {
+      "properties": {
+        "accounts": {
+          "items": {
+            "properties": {
+              "date_created": {
+                "description": "The date that this account was created, in GMT in RFC 2822 format",
+                "type": "string"
+              },
+              "date_updated": {
+                "description": "The date that this account was last updated, in GMT in RFC 2822 format.",
+                "type": "string"
+              },
+              "friendly_name": {
+                "description": "A human readable description of this account, up to 64 characters long. By default the FriendlyName is your email address.",
+                "type": "string"
+              },
+              "sid": {
+                "description": "A 34 character string that uniquely identifies this account.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of this account. Usually active, but can be suspended or closed.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of this account. Either Trial or Full if you've upgraded.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "null"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "null"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "appResource": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "sms_fallback_method": {
+          "type": "string"
+        },
+        "sms_fallback_url": {
+          "type": "string"
+        },
+        "sms_method": {
+          "type": "string"
+        },
+        "sms_status_callback": {
+          "type": "string"
+        },
+        "sms_url": {
+          "type": "string"
+        },
+        "status_callback": {
+          "type": "string"
+        },
+        "status_callback_method": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "voice_caller_id_lookup": {
+          "type": "string"
+        },
+        "voice_fallback_method": {
+          "type": "string"
+        },
+        "voice_fallback_url": {
+          "type": "string"
+        },
+        "voice_method": {
+          "type": "string"
+        },
+        "voice_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "appResources": {
+      "properties": {
+        "applications": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "sms_fallback_method": {
+                "type": "string"
+              },
+              "sms_fallback_url": {
+                "type": "string"
+              },
+              "sms_method": {
+                "type": "string"
+              },
+              "sms_status_callback": {
+                "type": "string"
+              },
+              "sms_url": {
+                "type": "string"
+              },
+              "status_callback": {
+                "type": "string"
+              },
+              "status_callback_method": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "voice_caller_id_lookup": {
+                "type": "string"
+              },
+              "voice_fallback_method": {
+                "type": "string"
+              },
+              "voice_fallback_url": {
+                "type": "string"
+              },
+              "voice_method": {
+                "type": "string"
+              },
+              "voice_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "application": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "sms_fallback_method": {
+          "type": "string"
+        },
+        "sms_fallback_url": {
+          "type": "object"
+        },
+        "sms_method": {
+          "type": "string"
+        },
+        "sms_status_callback": {
+          "type": "object"
+        },
+        "sms_url": {
+          "type": "object"
+        },
+        "status_callback": {
+          "type": "object"
+        },
+        "status_callback_method": {
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "voice_caller_id_lookup": {
+          "type": "object"
+        },
+        "voice_fallback_method": {
+          "type": "string"
+        },
+        "voice_fallback_url": {
+          "type": "object"
+        },
+        "voice_method": {
+          "type": "string"
+        },
+        "voice_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "applications": {
+      "properties": {
+        "applications": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "sms_fallback_method": {
+                "type": "object"
+              },
+              "sms_fallback_url": {
+                "type": "object"
+              },
+              "sms_method": {
+                "type": "object"
+              },
+              "sms_status_callback": {
+                "type": "object"
+              },
+              "sms_url": {
+                "type": "object"
+              },
+              "status_callback": {
+                "type": "object"
+              },
+              "status_callback_method": {
+                "type": "object"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "voice_caller_id_lookup": {
+                "type": "object"
+              },
+              "voice_fallback_method": {
+                "type": "object"
+              },
+              "voice_fallback_url": {
+                "type": "object"
+              },
+              "voice_method": {
+                "type": "string"
+              },
+              "voice_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "authApp": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "connect_app_company_name": {
+          "type": "string"
+        },
+        "connect_app_description": {
+          "type": "string"
+        },
+        "connect_app_friendly_name": {
+          "type": "string"
+        },
+        "connect_app_homepage_url": {
+          "type": "string"
+        },
+        "connect_app_sid": {
+          "type": "string"
+        },
+        "permissions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "authApps": {
+      "properties": {
+        "authorized_connect_apps": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "connect_app_company_name": {
+                "type": "string"
+              },
+              "connect_app_description": {
+                "type": "string"
+              },
+              "connect_app_friendly_name": {
+                "type": "string"
+              },
+              "connect_app_homepage_url": {
+                "type": "string"
+              },
+              "connect_app_sid": {
+                "type": "string"
+              },
+              "permissions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "availablePhoneNumbers": {
+      "properties": {
+        "available_phone_numbers": {
+          "items": {
+            "properties": {
+              "capabilities": {
+                "properties": {
+                  "MMS": {
+                    "type": "string"
+                  },
+                  "SMS": {
+                    "type": "string"
+                  },
+                  "voice": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "iso_country": {
+                "type": "string"
+              },
+              "lata": {
+                "type": "string"
+              },
+              "latitude": {
+                "type": "string"
+              },
+              "longitude": {
+                "type": "string"
+              },
+              "phone_number": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "string"
+              },
+              "rate_center": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "call": {
+      "properties": {
+        "account_sid": {
+          "description": "The unique id of the Account responsible for creating this call.",
+          "type": "string"
+        },
+        "answered_by": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "caller_name": {
+          "type": "string"
+        },
+        "date_created": {
+          "description": "GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "end_time": {
+          "description": "Given as GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "formatted_from": {
+          "type": "string"
+        },
+        "formatted_to": {
+          "type": "string"
+        },
+        "forwarded_from": {
+          "type": "string"
+        },
+        "from": {
+          "description": "The phone number, SIP address or Client identifier that made this call. Phone numbers are in E.164 format (e.g. +16175551212).",
+          "type": "string"
+        },
+        "parent_call_sid": {
+          "maxLength": 34,
+          "minLength": 34,
+          "type": "string"
+        },
+        "phone_number_sid": {
+          "type": "string"
+        },
+        "price": {
+          "type": "string"
+        },
+        "sid": {
+          "maxLength": 34,
+          "minLength": 34,
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Given as GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "queued",
+            "ringing",
+            "in-progress",
+            "canceled",
+            "completed",
+            "failed",
+            "busy",
+            "no-answer"
+          ]
+        },
+        "subresource_uris": {
+          "properties": {
+            "notifications": {
+              "type": "string"
+            },
+            "recordings": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "to": {
+          "description": "Phone numbers are in E.164 format (e.g. +16175551212). SIP addresses are formated as name@company.com. Client identifiers are formatted client:name.",
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "callInstance": {
+      "properties": {
+        "account_sid": {
+          "description": "The unique id of the Account responsible for creating this call.",
+          "type": "string"
+        },
+        "answered_by": {
+          "description": "If this call was initiated with answering machine detection, either human or machine. Empty otherwise.",
+          "enum": [
+            "null",
+            "human",
+            "machine"
+          ]
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "caller_name": {
+          "description": "If this call was an incoming call to a phone number with Caller ID Lookup enabled, the caller's name. Empty otherwise.",
+          "type": "string"
+        },
+        "date_created": {
+          "description": "GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "direction": {
+          "description": "A string describing the direction of the call. inbound for inbound calls, outbound-api for calls initiated via the REST API or outbound-dial for calls initiated by a <Dial> verb.",
+          "enum": [
+            "inbound",
+            "outbound-api",
+            "outbound-dial"
+          ]
+        },
+        "duration": {
+          "description": "The length of the call in seconds.",
+          "type": "string"
+        },
+        "end_time": {
+          "description": "Given as GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "forwarded_from": {
+          "description": "If this call was an incoming call forwarded from another number, the forwarding phone number (depends on carrier supporting forwarding). Empty otherwise.",
+          "type": "string"
+        },
+        "from": {
+          "description": "The phone number, SIP address or Client identifier that made this call. Phone numbers are in E.164 format (e.g. +16175551212).",
+          "type": "string"
+        },
+        "parent_call_sid": {
+          "maxLength": 34,
+          "minLength": 34,
+          "type": "string"
+        },
+        "phone_number_sid": {
+          "description": "If the call was inbound, this is the Sid of the IncomingPhoneNumber that received the call. If the call was outbound, it is the Sid of the OutgoingCallerId from which the call was placed.",
+          "type": "string"
+        },
+        "price": {
+          "description": "The charge for this call, in the currency associated with the account. Populated after the call is completed. May not be immediately available.",
+          "type": "string"
+        },
+        "price_unit": {
+          "description": "The currency in which Price is measured, in ISO 4127 format.",
+          "type": "string"
+        },
+        "sid": {
+          "maxLength": 34,
+          "minLength": 34,
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Given as GMT in RFC 2822 format.",
+          "type": "string"
+        },
+        "status": {
+          "description": "A string representing the status of the call.",
+          "enum": [
+            "queued",
+            "ringing",
+            "in-progress",
+            "canceled",
+            "completed",
+            "failed",
+            "busy",
+            "no-answer"
+          ]
+        },
+        "subresource_uris": {
+          "type": "object"
+        },
+        "to": {
+          "description": "Phone numbers are in E.164 format (e.g. +16175551212). SIP addresses are formated as name@company.com. Client identifiers are formatted client:name.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI for this resource, relative to https://api.twilio.com",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "calls": {
+      "properties": {
+        "calls": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "answered_by": {
+                "type": "object"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "caller_name": {
+                "type": "object"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "direction": {
+                "type": "string"
+              },
+              "duration": {
+                "type": "string"
+              },
+              "end_time": {
+                "type": "string"
+              },
+              "forwarded_from": {
+                "type": "object"
+              },
+              "from": {
+                "type": "string"
+              },
+              "from_formatted": {
+                "type": "string"
+              },
+              "parent_call_sid": {
+                "type": "object"
+              },
+              "phone_number_sid": {
+                "type": "string"
+              },
+              "price": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "start_time": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "subresource_uris": {
+                "properties": {
+                  "notifications": {
+                    "type": "string"
+                  },
+                  "recordings": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "to": {
+                "type": "string"
+              },
+              "to_formatted": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "conference": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "init",
+            "in-progress",
+            "completed"
+          ]
+        },
+        "subresource_uris": {
+          "properties": {
+            "participants": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "conferences": {
+      "properties": {
+        "conferences": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "subresource_uris": {
+                "properties": {
+                  "participants": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "connectApp": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "authorize_redirect_url": {
+          "type": "string"
+        },
+        "company_name": {
+          "type": "string"
+        },
+        "deauthorize_callback_method": {
+          "type": "string"
+        },
+        "deauthorize_callback_url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "homepage_url": {
+          "type": "string"
+        },
+        "permissions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sid": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "connectApps": {
+      "properties": {
+        "connect_apps": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "authorize_redirect_url": {
+                "type": "string"
+              },
+              "company_name": {
+                "type": "string"
+              },
+              "deauthorize_callback_method": {
+                "type": "string"
+              },
+              "deauthorize_callback_url": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "homepage_url": {
+                "type": "string"
+              },
+              "permissions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "sid": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "credential": {
+      "properties": {
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "credentialList": {
+      "properties": {
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "subresource_uris": {
+          "properties": {
+            "credentials": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "credentialListMapping": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "subresource_uris": {
+          "properties": {
+            "credentials": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "credentialListMappings": {
+      "properties": {
+        "credential_list_mappings": {
+          "items": {
+            "items": {
+              "properties": {
+                "account_sid": {
+                  "type": "string"
+                },
+                "date_created": {
+                  "type": "string"
+                },
+                "date_updated": {
+                  "type": "string"
+                },
+                "friendly_name": {
+                  "type": "string"
+                },
+                "sid": {
+                  "type": "string"
+                },
+                "subresource_uris": {
+                  "properties": {
+                    "credentials": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "uri": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "credentialLists": {
+      "properties": {
+        "credential_lists": {
+          "items": {
+            "properties": {
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "subresource_uris": {
+                "properties": {
+                  "credentials": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "credentials": {
+      "properties": {
+        "credentials": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "credential_list_sid": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "domain": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "auth_type": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "domain_name": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "subresource_uris": {
+          "properties": {
+            "credential_list_mappings": {
+              "type": "string"
+            },
+            "ip_access_control_list_mappings": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "voice_fallback_method": {
+          "type": "string"
+        },
+        "voice_fallback_url": {
+          "type": "object"
+        },
+        "voice_method": {
+          "type": "string"
+        },
+        "voice_status_callback_method": {
+          "type": "string"
+        },
+        "voice_status_callback_url": {
+          "type": "object"
+        },
+        "voice_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "domains": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "sip_domains": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "auth_type": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "domain_name": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "subresource_uris": {
+                "properties": {
+                  "credential_list_mappings": {
+                    "type": "string"
+                  },
+                  "ip_access_control_list_mappings": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "voice_fallback_method": {
+                "type": "string"
+              },
+              "voice_fallback_url": {
+                "type": "object"
+              },
+              "voice_method": {
+                "type": "string"
+              },
+              "voice_status_callback_method": {
+                "type": "string"
+              },
+              "voice_status_callback_url": {
+                "type": "object"
+              },
+              "voice_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "incomingCall": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "capabilities": {
+          "properties": {
+            "sms": {
+              "type": "string"
+            },
+            "voice": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "phone_number": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "sms_application_sid": {
+          "type": "string"
+        },
+        "sms_fallback_method": {
+          "type": "string"
+        },
+        "sms_fallback_url": {
+          "type": "string"
+        },
+        "sms_method": {
+          "type": "string"
+        },
+        "sms_url": {
+          "type": "string"
+        },
+        "status_callback": {
+          "type": "string"
+        },
+        "status_callback_method": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "voice_application_sid": {
+          "type": "string"
+        },
+        "voice_caller_id_lookup": {
+          "type": "string"
+        },
+        "voice_fallback_method": {
+          "type": "string"
+        },
+        "voice_fallback_url": {
+          "type": "string"
+        },
+        "voice_method": {
+          "type": "string"
+        },
+        "voice_url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "incomingCalls": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "incoming_phone_numbers": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "capabilities": {
+                "properties": {
+                  "sms": {
+                    "type": "boolean"
+                  },
+                  "voice": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "phone_number": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "sms_application_sid": {
+                "type": "string"
+              },
+              "sms_fallback_method": {
+                "type": "object"
+              },
+              "sms_fallback_url": {
+                "type": "object"
+              },
+              "sms_method": {
+                "type": "object"
+              },
+              "sms_url": {
+                "type": "object"
+              },
+              "status_callback": {
+                "type": "object"
+              },
+              "status_callback_method": {
+                "type": "object"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "voice_application_sid": {
+                "type": "object"
+              },
+              "voice_caller_id_lookup": {
+                "type": "object"
+              },
+              "voice_fallback_method": {
+                "type": "object"
+              },
+              "voice_fallback_url": {
+                "type": "object"
+              },
+              "voice_method": {
+                "type": "string"
+              },
+              "voice_url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ipAccessControlList": {
+      "properties": {
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "subresource_uris": {
+          "properties": {
+            "addresses": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ipAccessControlListMapping": {
+      "properties": {
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "subresource_uris": {
+          "properties": {
+            "addresses": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ipAccessControlListMappings": {
+      "properties": {
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "subresource_uris": {
+          "properties": {
+            "addresses": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ipAddress": {
+      "properties": {
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "ip_address": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ipAddresses": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "ip_addresses": {
+          "items": {
+            "properties": {
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "ip_address": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "media": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "content-type": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "parent_sid": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mediaList": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "media_list": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "content_type": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "parent_sid": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "member": {
+      "properties": {
+        "call_sid": {
+          "type": "string"
+        },
+        "date_enqueued": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "wait_time": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "members": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "queue_members": {
+          "items": {
+            "properties": {
+              "call_sid": {
+                "type": "string"
+              },
+              "date_enqueued": {
+                "type": "string"
+              },
+              "position": {
+                "type": "integer"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "wait_time": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "message": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_sent": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "from": {
+          "type": "string"
+        },
+        "num_media": {
+          "type": "string"
+        },
+        "num_segments": {
+          "type": "string"
+        },
+        "price": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "messages": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_sent": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "direction": {
+                "type": "string"
+              },
+              "from": {
+                "type": "string"
+              },
+              "num_media": {
+                "type": "string"
+              },
+              "num_segments": {
+                "type": "string"
+              },
+              "price": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mobilePhoneNumbers": {
+      "properties": {
+        "available_phone_numbers": {
+          "items": {
+            "properties": {
+              "capabilities": {
+                "properties": {
+                  "MMS": {
+                    "type": "string"
+                  },
+                  "SMS": {
+                    "type": "string"
+                  },
+                  "voice": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "iso_country": {
+                "type": "string"
+              },
+              "lata": {
+                "type": "object"
+              },
+              "latitude": {
+                "type": "object"
+              },
+              "longitude": {
+                "type": "object"
+              },
+              "phone_number": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "object"
+              },
+              "rate_center": {
+                "type": "object"
+              },
+              "region": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "notification": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "call_sid": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "error_code": {
+          "type": "string"
+        },
+        "log": {
+          "type": "string"
+        },
+        "message_date": {
+          "type": "string"
+        },
+        "message_text": {
+          "type": "string"
+        },
+        "more_info": {
+          "type": "string"
+        },
+        "request_method": {
+          "type": "string"
+        },
+        "request_url": {
+          "type": "string"
+        },
+        "request_variables": {
+          "type": "string"
+        },
+        "response_body": {
+          "type": "string"
+        },
+        "response_headers": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "notifications": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "notifications": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "call_sid": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "error_code": {
+                "type": "string"
+              },
+              "log": {
+                "type": "string"
+              },
+              "message_date": {
+                "type": "string"
+              },
+              "message_text": {
+                "type": "string"
+              },
+              "more_info": {
+                "type": "string"
+              },
+              "request_method": {
+                "type": "string"
+              },
+              "request_url": {
+                "type": "string"
+              },
+              "request_variables": {
+                "type": "string"
+              },
+              "response_body": {
+                "type": "string"
+              },
+              "response_headers": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "outCaller": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "call_sid": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "phone_number": {
+          "type": "string"
+        },
+        "validation_code": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "outCallerId": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "call_sid": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "phone_number": {
+          "type": "string"
+        },
+        "validation_code": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "outCallerIds": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "outgoing_caller_ids": {
+          "properties": {
+            "account_sid": {
+              "type": "string"
+            },
+            "date_created": {
+              "type": "string"
+            },
+            "date_updated": {
+              "type": "string"
+            },
+            "friendly_name": {
+              "type": "string"
+            },
+            "phone_number": {
+              "type": "string"
+            },
+            "sid": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "outgoingCallerId": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "phone_number": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "participant": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "call_sid": {
+          "type": "string"
+        },
+        "conference_sid": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "end_conference_on_exit": {
+          "type": "boolean"
+        },
+        "muted": {
+          "type": "boolean"
+        },
+        "start_conference_on_enter": {
+          "type": "boolean"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "participants": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "participants": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "call_sid": {
+                "type": "string"
+              },
+              "conference_sid": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "end_conference_on_exit": {
+                "type": "boolean"
+              },
+              "muted": {
+                "type": "boolean"
+              },
+              "start_conference_on_enter": {
+                "type": "boolean"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "phoneLocalNumbers": {
+      "properties": {
+        "available_phone_numbers": {
+          "items": {
+            "properties": {
+              "capabilities": {
+                "properties": {
+                  "MMS": {
+                    "type": "string"
+                  },
+                  "SMS": {
+                    "type": "string"
+                  },
+                  "voice": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "iso_country": {
+                "type": "string"
+              },
+              "lata": {
+                "type": "string"
+              },
+              "latitude": {
+                "type": "string"
+              },
+              "longitude": {
+                "type": "string"
+              },
+              "phone_number": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "string"
+              },
+              "rate_center": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "phoneMobileNumbers": {
+      "properties": {
+        "available_phone_numbers": {
+          "items": {
+            "properties": {
+              "capabilities": {
+                "properties": {
+                  "MMS": {
+                    "type": "string"
+                  },
+                  "SMS": {
+                    "type": "string"
+                  },
+                  "voice": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "iso_country": {
+                "type": "string"
+              },
+              "lata": {
+                "type": "object"
+              },
+              "latitude": {
+                "type": "object"
+              },
+              "longitude": {
+                "type": "object"
+              },
+              "phone_number": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "object"
+              },
+              "rate_center": {
+                "type": "object"
+              },
+              "region": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "phoneNumbers": {
+      "properties": {
+        "available_phone_numbers": {
+          "items": {
+            "properties": {
+              "friendly_name": {
+                "description": "A nicely-formatted version of the phone number.",
+                "type": "string"
+              },
+              "iso_country": {
+                "description": "The ISO country code of this phone number.",
+                "type": "string"
+              },
+              "lata": {
+                "description": "The LATA of this phone number.",
+                "type": "string"
+              },
+              "latitude": {
+                "description": "The latitude coordinate of this phone number.",
+                "type": "string"
+              },
+              "longitude": {
+                "description": "The longitude coordinate of this phone number.",
+                "type": "string"
+              },
+              "phone_number": {
+                "description": "The phone number, in E.164 (i.e. '+1') format.",
+                "type": "string"
+              },
+              "postal_code": {
+                "description": "The postal (zip) code of this phone number.",
+                "type": "string"
+              },
+              "rate_center": {
+                "description": "The rate center of this phone number.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The two-letter state or province abbreviation of this phone number.",
+                "maxLength": 2,
+                "minLength": 2,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "phoneTollFreeNumbers": {
+      "properties": {
+        "available_phone_numbers": {
+          "items": {
+            "properties": {
+              "capabilities": {
+                "properties": {
+                  "MMS": {
+                    "type": "string"
+                  },
+                  "SMS": {
+                    "type": "string"
+                  },
+                  "voice": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "iso_country": {
+                "type": "string"
+              },
+              "phone_number": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "queue": {
+      "properties": {
+        "average_wait_time": {
+          "type": "integer"
+        },
+        "current_size": {
+          "type": "integer"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "max_size": {
+          "maximum": 1000,
+          "type": "integer"
+        },
+        "sid": {
+          "maxLength": 34,
+          "minLength": 34,
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "queues": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "queues": {
+          "items": {
+            "properties": {
+              "average_wait_time": {
+                "type": "integer"
+              },
+              "current_size": {
+                "type": "integer"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "max_size": {
+                "maximum": 1000,
+                "type": "integer"
+              },
+              "sid": {
+                "maxLength": 34,
+                "minLength": 34,
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "recordings": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "recordings": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "call_sid": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "duration": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "shortCode": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "friendly_name": {
+          "type": "string"
+        },
+        "short_code": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "sms_fallback_method": {
+          "type": "string"
+        },
+        "sms_fallback_url": {
+          "type": "string"
+        },
+        "sms_method": {
+          "type": "string"
+        },
+        "sms_url": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "shortCodes": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "short_codes": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "short_code": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "sms_fallback_method": {
+                "type": "string"
+              },
+              "sms_fallback_url": {
+                "type": "string"
+              },
+              "sms_method": {
+                "type": "string"
+              },
+              "sms_url": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "transcription": {
+      "properties": {
+        "account_sid": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "date_created": {
+          "type": "string"
+        },
+        "date_updated": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "price": {
+          "type": "string"
+        },
+        "recording_sid": {
+          "type": "string"
+        },
+        "sid": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "transcription_text": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "transcriptions": {
+      "properties": {
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "transcriptions": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "api_version": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "duration": {
+                "type": "string"
+              },
+              "price": {
+                "type": "string"
+              },
+              "recording_sid": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "transcription_text": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "usageRecords": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "usage_records": {
+          "properties": {
+            "account_sid": {
+              "type": "string"
+            },
+            "category": {
+              "type": "string"
+            },
+            "count": {
+              "type": "string"
+            },
+            "count_unit": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "end_date": {
+              "type": "string"
+            },
+            "price": {
+              "type": "string"
+            },
+            "price_unit": {
+              "type": "string"
+            },
+            "start_date": {
+              "type": "string"
+            },
+            "subresource_uris": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            },
+            "usage": {
+              "type": "string"
+            },
+            "usage_unit": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "usageTrigger": {
+      "properties": {
+        "account_sid": {
+          "description": "The account this trigger monitors.",
+          "type": "string"
+        },
+        "callback_method": {
+          "description": "The HTTP method Twilio will use when making a request to the CallbackUrl. GET or POST.",
+          "enum": [
+            "GET",
+            "POST"
+          ]
+        },
+        "callback_url": {
+          "description": "Twilio will make a request to this url when the trigger fires.",
+          "type": "string"
+        },
+        "current_value": {
+          "description": "The current value of the field the trigger is watching.",
+          "type": "string"
+        },
+        "date_created": {
+          "description": "The date the trigger was created, given as GMT RFC 2822 format.",
+          "type": "string"
+        },
+        "date_fired": {
+          "description": "The date the trigger was last fired, given as GMT RFC 2822 format.",
+          "type": "string"
+        },
+        "date_updated": {
+          "description": "The date the trigger was last updated, given as GMT RFC 2822 format.",
+          "type": "string"
+        },
+        "friendly_name": {
+          "description": "A user-specified, human-readable name for the trigger.",
+          "type": "string"
+        },
+        "recurring": {
+          "description": "How this trigger recurs. Empty for non-recurring triggers. One of daily, monthly, or yearly for recurring triggers. A trigger will only fire once during each recurring period. Recurring periods are in GMT.",
+          "type": "string"
+        },
+        "sid": {
+          "description": "The trigger's unique Sid.",
+          "type": "string"
+        },
+        "trigger_by": {
+          "description": "The field in the UsageRecord that fires the trigger. One of count, usage, or price.",
+          "enum": [
+            "count",
+            "usage",
+            "price"
+          ]
+        },
+        "trigger_value": {
+          "description": "The value at which the trigger will fire. Must be a positive numeric value.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI for this resource, relative to https://api.twilio.com.",
+          "type": "string"
+        },
+        "usage_category": {
+          "description": "The usage category the trigger watches. One of the supported usage categories.",
+          "type": "string"
+        },
+        "usage_record_uri": {
+          "description": "The URI of the UsageRecord this trigger is watching, relative to https://api.twilio.com.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "usageTriggers": {
+      "properties": {
+        "end": {
+          "type": "integer"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "string"
+        },
+        "num_pages": {
+          "type": "integer"
+        },
+        "page": {
+          "type": "integer"
+        },
+        "page_size": {
+          "type": "integer"
+        },
+        "previous_page_uri": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "usage_triggers": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "callback_method": {
+                "enum": [
+                  "GET",
+                  "POST"
+                ]
+              },
+              "callback_url": {
+                "type": "string"
+              },
+              "current_value": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_fired": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "recurring": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "trigger_by": {
+                "enum": [
+                  "count",
+                  "usage",
+                  "price"
+                ]
+              },
+              "trigger_value": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "usage_category": {
+                "type": "string"
+              },
+              "usage_record_uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "userLists": {
+      "properties": {
+        "credential_list_mappings": {
+          "items": {
+            "properties": {
+              "account_sid": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "friendly_name": {
+                "type": "string"
+              },
+              "sid": {
+                "type": "string"
+              },
+              "subresource_uris": {
+                "properties": {
+                  "credentials": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "end": {
+          "type": "number"
+        },
+        "first_page_uri": {
+          "type": "string"
+        },
+        "last_page_uri": {
+          "type": "string"
+        },
+        "next_page_uri": {
+          "type": "object"
+        },
+        "num_pages": {
+          "type": "number"
+        },
+        "page": {
+          "type": "number"
+        },
+        "page_size": {
+          "type": "number"
+        },
+        "previous_page_uri": {
+          "type": "object"
+        },
+        "start": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "uri": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/hubs/swagger/uber.json
+++ b/hubs/swagger/uber.json
@@ -1,0 +1,370 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uber API",
+    "description": "Move your app forward with the Uber API",
+    "version": "1.0.0"
+  },
+  "host": "api.uber.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/products": {
+      "get": {
+        "summary": "Product Types",
+        "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "description": "Latitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "description": "Longitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/price": {
+      "get": {
+        "summary": "Price Estimates",
+        "description": "The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.",
+        "parameters": [
+          {
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_latitude",
+            "in": "query",
+            "description": "Latitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_longitude",
+            "in": "query",
+            "description": "Longitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of price estimates by product",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PriceEstimate"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/time": {
+      "get": {
+        "summary": "Time Estimates",
+        "description": "The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.",
+        "parameters": [
+          {
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "customer_uuid",
+            "in": "query",
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique customer identifier to be used for experience customization."
+          },
+          {
+            "name": "product_id",
+            "in": "query",
+            "type": "string",
+            "description": "Unique identifier representing a specific product for a given latitude & longitude."
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "summary": "User Profile",
+        "description": "The User Profile endpoint returns information about the Uber user that has authorized with the application.",
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile information for a user",
+            "schema": {
+              "$ref": "#/definitions/Profile"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/history": {
+      "get": {
+        "summary": "User Activity",
+        "description": "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.",
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Offset the list of returned results by this amount. Default is zero."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of items to retrieve. Default is 5, maximum is 100."
+          }
+        ],
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "History information for the given user",
+            "schema": {
+              "$ref": "#/definitions/Activities"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "capacity": {
+          "type": "string",
+          "description": "Capacity of product. For example, 4 people."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image URL representing the product."
+        }
+      }
+    },
+    "PriceEstimate": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles"
+        },
+        "currency_code": {
+          "type": "string",
+          "description": "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "estimate": {
+          "type": "string",
+          "description": "Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or \"Metered\" for TAXI."
+        },
+        "low_estimate": {
+          "type": "number",
+          "description": "Lower bound of the estimated price."
+        },
+        "high_estimate": {
+          "type": "number",
+          "description": "Upper bound of the estimated price."
+        },
+        "surge_multiplier": {
+          "type": "number",
+          "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier."
+        }
+      }
+    },
+    "Profile": {
+      "properties": {
+        "first_name": {
+          "type": "string",
+          "description": "First name of the Uber user."
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name of the Uber user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the Uber user"
+        },
+        "picture": {
+          "type": "string",
+          "description": "Image URL of the Uber user."
+        },
+        "promo_code": {
+          "type": "string",
+          "description": "Promo code of the Uber user."
+        }
+      }
+    },
+    "Activity": {
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "Unique identifier for the activity"
+        }
+      }
+    },
+    "Activities": {
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Position in pagination."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of items to retrieve (100 max)."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items available."
+        },
+        "history": {
+          "type": "array",
+          "items": {
+              "$ref": "#/definitions/Activity"
+           }
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These swagger specifications were present in Bump code (spec fixtures), but not used anymore.

Since there are removed by https://github.com/bump-sh/bump/pull/2500, this PR allow to save them in this repo example

PS: MealCanteen spec is buggy.