### PR TITLE
gitlab: add Gitlab API example

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -29,3 +29,4 @@ jobs:
           BUMP_HOST: ${{ secrets.BUMP_HOST }}
           GREENLY_BUMP_TOKEN: ${{ secrets.GREENLY_BUMP_TOKEN }}
           PIPEDRIVE_BUMP_TOKEN:  ${{ secrets.PIPEDRIVE_BUMP_TOKEN }}
+          GITLAB_BUMP_TOKEN: ${{ secrets.GITLAB_BUMP_TOKEN }}

--- a/apis/README.md
+++ b/apis/README.md
@@ -14,6 +14,7 @@ The files are automatically deployed to Bump.sh:
 - Clever-Cloud API documentation: https://bump.sh/demo/doc/clever-cloud
 - Pipedrive API documentation: https://bump.sh/demo/doc/pipedrive
 - Greenly API documentation: https://bump.sh/demo/doc/greenly
+- Gitlab API documentation: https://bump.sh/demo/doc/gitlab
 
 ## How to add an API here?
 

--- a/apis/gitlab-openapi-source.yaml
+++ b/apis/gitlab-openapi-source.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.0
+tags:
+  - name: version
+    description: Version
+  - name: access_requests
+    description: Access requests for projects and groups
+  - name: access_tokens
+    description: Access tokens for projects
+info:
+  description: |
+    An OpenAPI definition for the GitLab REST API.
+    Few API resources or endpoints are currently included.
+    The intent is to expand this to match the entire Markdown documentation of the API:
+    <https://docs.gitlab.com/ee/api/>. Contributions are welcome.
+
+    When viewing this on gitlab.com, you can test API calls directly from the browser
+    against the `gitlab.com` instance, if you are logged in.
+    The feature uses the current [GitLab session cookie](https://docs.gitlab.com/ee/api/index.html#session-cookie),
+    so each request is made using your account.
+
+    Instructions for using this tool can be found in [Interactive API Documentation](openapi_interactive.md).
+
+  version: v4
+  title: GitLab API
+  termsOfService: 'https://about.gitlab.com/terms/'
+  license:
+    name: CC BY-SA 4.0
+    url: 'https://gitlab.com/gitlab-org/gitlab/-/blob/master/LICENSE'
+servers:
+  - url: 'https://gitlab.com/api/'
+security:
+  - ApiKeyAuth: []
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Private-Token
+
+paths:
+  # VERSION
+  /v4/version:
+    $ref: 'gitlab-v4/version.yaml'
+
+  # ACCESS REQUESTS (PROJECTS)
+  /v4/projects/{id}/access_requests:
+    $ref: 'gitlab-v4/access_requests.yaml#/accessRequestsProjects'
+
+  /v4/projects/{id}/access_requests/{user_id}/approve:
+    $ref: 'gitlab-v4/access_requests.yaml#/accessRequestsProjectsApprove'
+
+  /v4/projects/{id}/access_requests/{user_id}:
+    $ref: 'gitlab-v4/access_requests.yaml#/accessRequestsProjectsDeny'
+
+  # ACCESS REQUESTS (GROUPS)
+  /v4/groups/{id}/access_requests:
+    $ref: 'gitlab-v4/access_requests.yaml#/accessRequestsGroups'
+
+  /v4/groups/{id}/access_requests/{user_id}/approve:
+    $ref: 'gitlab-v4/access_requests.yaml#/accessRequestsGroupsApprove'
+
+  /v4/groups/{id}/access_requests/{user_id}:
+    $ref: 'gitlab-v4/access_requests.yaml#/accessRequestsGroupsDeny'
+
+  # ACCESS REQUESTS (PROJECTS)
+  /v4/projects/{id}/access_tokens:
+    $ref: 'gitlab-v4/access_tokens.yaml#/accessTokens'
+
+  /v4/projects/{id}/access_tokens/{token_id}:
+    $ref: 'gitlab-v4/access_tokens.yaml#/accessTokensRevoke'

--- a/apis/gitlab-v4/access_requests.yaml
+++ b/apis/gitlab-v4/access_requests.yaml
@@ -1,0 +1,387 @@
+# Markdown documentation: https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/access_requests.md
+
+#/v4/projects/{id}/access_requests
+accessRequestsProjects:
+  get:
+    description: Lists access requests for a project
+    summary: List access requests for a project
+    operationId: accessRequestsProjects_get
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project owned by the authenticated user.
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+    responses:
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: ProjectAccessResponse
+              type: object
+              properties:
+                id:
+                  type: integer
+                usename:
+                  type: string
+                name:
+                  type: string
+                state:
+                  type: string
+                created_at:
+                  type: string
+                requested_at:
+                  type: string
+            example:
+              - "id": 1
+                "username": "raymond_smith"
+                "name": "Raymond Smith"
+                "state": "active"
+                "created_at": "2012-10-22T14:13:35Z"
+                "requested_at": "2012-10-22T14:13:35Z"                         
+              - "id": 2
+                "username": "john_doe"
+                "name": "John Doe"
+                "state": "active"
+                "created_at": "2012-10-22T14:13:35Z"
+                "requested_at": "2012-10-22T14:13:35Z"                         
+  post:
+    description: Requests access for the authenticated user to a project
+    summary: Requests access for the authenticated user to a project
+    operationId: accessRequestsProjects_post
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project owned by the authenticated user.
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+    responses:
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: ProjectAccessRequest
+              type: object
+              properties:
+                id:
+                  type: integer
+                usename:
+                  type: string
+                name:
+                  type: string
+                state:
+                  type: string
+                created_at:
+                  type: string
+                requested_at:
+                  type: string
+            example:
+              "id": 1
+              "username": "raymond_smith"
+              "name": "Raymond Smith"
+              "state": "active"
+              "created_at": "2012-10-22T14:13:35Z"
+              "requested_at": "2012-10-22T14:13:35Z"     
+
+#/v4/projects/{id}/access_requests/{user_id}/approve
+accessRequestsProjectsApprove:
+  put:
+    description: Approves access for the authenticated user to a project
+    summary: Approves access for the authenticated user to a project
+    operationId: accessRequestsProjectsApprove_put
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project owned by the authenticated user.
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+      - name: user_id
+        in: path
+        description: The userID of the access requester
+        required: true
+        schema:
+          type: integer
+      - name: access_level
+        in: query
+        description: A valid project access level.  0 = no access , 10 = guest, 20 = reporter, 30 = developer, 40 = Maintainer.  Default is 30.'
+        required: false
+        schema:
+          enum: [0, 10, 20, 30, 40]
+          default: 30
+          type: integer
+    responses:      
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: ProjectAccessApprove
+              type: object
+              properties:
+                id:
+                  type: integer
+                usename:
+                  type: string
+                name:
+                  type: string
+                state:
+                  type: string
+                created_at:
+                  type: string
+                access_level:
+                  type: integer
+            example:
+              "id": 1
+              "username": "raymond_smith"
+              "name": "Raymond Smith"
+              "state": "active"
+              "created_at": "2012-10-22T14:13:35Z"
+              "access_level": 20
+
+#/v4/projects/{id}/access_requests/{user_id}
+accessRequestsProjectsDeny:
+  delete:
+    description: Denies a project access request for the given user
+    summary: Denies a project access request for the given user
+    operationId: accessRequestProjectsDeny_delete
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project owned by the authenticated user.
+        required: true
+        schema:
+            oneOf:
+            - type: integer
+            - type: string
+      - name: user_id
+        in: path
+        description: The user ID of the access requester
+        required: true
+        schema:
+          type: integer
+    responses:    # Does anything go here?  Markdown doc does not list a response.
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+
+#/v4/groups/{id}/access_requests
+accessRequestsGroups:
+  get:
+    description: List access requests for a group
+    summary: List access requests for a group
+    operationId: accessRequestsGroups_get
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the group owned by the authenticated user.
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+    responses:
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: GroupAccessResponse
+              type: object
+              properties:
+                id:
+                  type: integer
+                usename:
+                  type: string
+                name:
+                  type: string
+                state:
+                  type: string
+                created_at:
+                  type: string
+                requested_at:
+                  type: string
+            example:
+              - "id": 1
+                "username": "raymond_smith"
+                "name": "Raymond Smith"
+                "state": "active"
+                "created_at": "2012-10-22T14:13:35Z"
+                "requested_at": "2012-10-22T14:13:35Z"                         
+              - "id": 2
+                "username": "john_doe"
+                "name": "John Doe"
+                "state": "active"
+                "created_at": "2012-10-22T14:13:35Z"
+                "requested_at": "2012-10-22T14:13:35Z"   
+  post:
+    description: Requests access for the authenticated user to a group
+    summary: Requests access for the authenticated user to a group
+    operationId: accessRequestsGroups_post
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the group owned by the authenticated user.
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+    responses:
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: GroupAccessRequest
+              type: object
+              properties:
+                id:
+                  type: integer
+                usename:
+                  type: string
+                name:
+                  type: string
+                state:
+                  type: string
+                created_at:
+                  type: string
+                requested_at:
+                  type: string
+            example:
+              "id": 1
+              "username": "raymond_smith"
+              "name": "Raymond Smith"
+              "state": "active"
+              "created_at": "2012-10-22T14:13:35Z"
+              "requested_at": "2012-10-22T14:13:35Z"                         
+
+#/v4/groups/{id}/access_requests/{user_id}/approve
+accessRequestsGroupsApprove:
+  put:
+    description: Approves access for the authenticated user to a group
+    summary: Approves access for the authenticated user to a group
+    operationId: accessRequestsGroupsApprove_put
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the group owned by the authenticated user.
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+      - name: user_id
+        in: path
+        description: The userID of the access requester
+        required: true
+        schema:
+          type: integer
+      - name: access_level
+        in: query
+        description: A valid group access level.  0 = no access , 10 = Guest, 20 = Reporter, 30 = Developer, 40 = Maintainer, 50 = Owner.  Default is 30.
+        required: false
+        schema:
+          enum: [0, 10, 20, 30, 40, 50]
+          default: 30
+          type: integer
+    responses:
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: GroupAccessApprove
+              type: object
+              properties:
+                id:
+                  type: integer
+                usename:
+                  type: string
+                name:
+                  type: string
+                email:
+                  type: string
+                state:
+                  type: string
+                created_at:
+                  type: string
+                access_level:
+                  type: integer
+            example:
+              "id": 1
+              "username": "raymond_smith"
+              "name": "Raymond Smith"
+              "state": "active"
+              "created_at": "2012-10-22T14:13:35Z"
+              "access_level": 20   
+
+#/v4/groups/{id}/access_requests/{user_id}
+accessRequestsGroupsDeny:
+  delete:
+    summary: Denies a group access request for the given user
+    description: |
+      Denies a group access request for the given user
+
+      > info
+        Hello world, what's up?
+    operationId: accessRequestsGroupsDeny_delete
+    tags:
+      - access_requests
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the group owned by the authenticated user.
+        required: true
+        schema:
+            oneOf:
+            - type: integer
+            - type: string
+      - name: user_id
+        in: path
+        description: The userID of the access requester
+        required: true
+        schema:
+          type: integer
+    responses:    # Does anything go here?  Markdown doc does not list a response.
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation

--- a/apis/gitlab-v4/access_tokens.yaml
+++ b/apis/gitlab-v4/access_tokens.yaml
@@ -1,0 +1,170 @@
+# Markdown documentation: https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/resource_access_tokens.md
+
+#/v4/projects/{id}/access_tokens
+accessTokens:
+  get:
+    description: Lists access tokens for a project
+    summary: List access tokens for a project
+    operationId: accessTokens_get
+    tags:
+      - access_tokens
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+    responses:
+      '404':
+        description: Not Found
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: AccessTokenList
+              type: object
+              properties:
+                user_id:
+                  type: integer
+                scopes:
+                  type: array
+                name:
+                  type: string
+                expires_at:
+                  type: date
+                id:
+                  type: integer
+                active:
+                  type: boolean
+                created_at:
+                  type: date
+                revoked:
+                  type: boolean
+            example:
+              "user_id": 141
+              "scopes" : ["api"]
+              "name": "token"
+              "expires_at": "2022-01-31"
+              "id": 42
+              "active": true
+              "created_at": "2021-01-20T14:13:35Z"
+              "revoked" : false
+  post:
+    description: Creates an access token for a project
+    summary: Creates an access token for a project
+    operationId: accessTokens_post
+    tags:
+      - access_tokens
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+      - name: name
+        in: query
+        description: The name of the project access token
+        required: true
+        schema:
+          type: string
+      - name: scopes
+        in: query
+        description: Defines read and write permissions for the token
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+            enum: ["api", "read_api", "read_registry", "write_registry", "read_repository", "write_repository"]
+      - name: expires_at
+        in: query
+        description: Date when the token expires. Time of day is Midnight UTC of that date.
+        required: false
+        schema:
+          type: date
+    responses:
+      '404':
+        description: Not Found
+      '401':
+        description: Unauthorized operation
+      '200':
+        description: Successful operation
+        content:
+          application/json:
+            schema:
+              title: AccessTokenList
+              type: object
+              properties:
+                user_id:
+                  type: integer
+                scopes:
+                  type: array
+                name:
+                  type: string
+                expires_at:
+                  type: date
+                id:
+                  type: integer
+                active:
+                  type: boolean
+                created_at:
+                  type: date
+                revoked:
+                  type: boolean
+                token:
+                  type: string
+            example:
+              "user_id": 166
+              "scopes" : [
+                "api",
+                "read_repository"
+              ]
+              "name": "test"
+              "expires_at": "2022-01-31"
+              "id": 58
+              "active": true
+              "created_at": "2021-01-20T14:13:35Z"
+              "revoked" : false
+              "token" : "D4y...Wzr"
+
+#/v4/projects/{id}/access_tokens/{token_id}
+accessTokensRevoke:
+  delete:
+    description: Revokes an access token
+    summary: Revokes an access token
+    operationId: accessTokens_delete
+    tags:
+      - access_tokens
+    parameters:
+      - name: id
+        in: path
+        description: The ID or URL-encoded path of the project
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+      - name: token_id
+        in: path
+        description: The ID of the project access token
+        required: true
+        schema:
+          oneOf:
+            - type: integer
+            - type: string
+    responses:
+      '400':
+        description: Bad Request
+      '404':
+        description: Not Found
+      '204':
+        description: No content if successfully revoked

--- a/apis/gitlab-v4/version.yaml
+++ b/apis/gitlab-v4/version.yaml
@@ -1,0 +1,28 @@
+# Markdown documentation: https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/version.md
+
+get:
+  tags:
+    - version
+  summary: "Retrieve version information for this GitLab instance."
+  operationId: "getVersion"
+  responses:
+    "401":
+      description: "unauthorized operation"
+    "200":
+      description: "successful operation"
+      content:
+        "application/json":
+          schema:
+            title: "VersionResponse"
+            type: "object"
+            properties:
+              version:
+                type: "string"
+              revision:
+                type: "string"
+          examples:
+            Example:
+              value:
+                version: "13.3.0-pre"
+                revision: "f2b05afebb0"
+


### PR DESCRIPTION
This example is added to be able to remove the specific repository we
had with the Gitlab example (here
https://github.com/bump-sh/gitlab-api-example).

I added a `GITLAB_BUMP_TOKEN` secret variable in this repo and created
the documentation on our Demo
organization (https://bump.sh/demo/docs/d50d7287-ff43-4d88-b930-e23d3bf03004).