### PR TITLE
ci: add a diff GH action workflow to showcase Bump diffs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     name: Deploy API documentations on Bump
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,48 @@
+name: API diff on Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  pull_request_target:
+    branches:
+      - main
+
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gitlab-api-diff:
+    if: ${{ github.event_name == 'pull_request_target' }}
+    name: Check public Gitlab API diff on Bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Comment pull request with API diff
+        uses: bump-sh/github-action@v1
+        with:
+          file: apis/gitlab-openapi-source.yaml
+          command: diff
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  greenly-api-diff:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Check Greenly API diff on Bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Comment pull request with API diff
+        uses: bump-sh/github-action@v1
+        with:
+          doc: greenly
+          token: ${{ secrets.GREENLY_BUMP_TOKEN }}
+          file: apis/greenly-openapi-source.json
+          command: diff
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR adds an extra a separate diff workflow file to showcase Bump
Diffs as an example on how to run API diff in PRs.