### PR TITLE
deploy: improve debugging logs in deploy script

### DIFF
--- a/.github/scripts/deploy-all.sh
+++ b/.github/scripts/deploy-all.sh
@@ -24,7 +24,7 @@ for hub in hubs/*/; do
         # Create documentation <apiName> from the api definition file
         tokenKey="${hubName//-/_}_BUMP_TOKEN"
         tokenKey="${tokenKey^^}"
-        echo "* API ${apiName}"
+        echo "* API ${apiName} (reading token from ${tokenKey})"
         bump deploy --doc "${apiName}" --token "${!tokenKey}" --hub "${hubName}" --auto-create "${api}"
     done
 done
@@ -40,6 +40,6 @@ for api in apis/*-source.{yml,yaml,json}; do
     # Create documentation <apiName> from the api definition file
     tokenKey="${apiName//-/_}_BUMP_TOKEN"
     tokenKey="${tokenKey^^}"
-    echo "* API ${apiName}"
+    echo "* API ${apiName} (reading token from ${tokenKey})"
     bump deploy --doc "${apiName}" --token "${!tokenKey}" "${api}"
 done


### PR DESCRIPTION
Not sure why in the current deployment we get an error on the Atlan
docs:

```
* API atlan
./.github/scripts/deploy-all.sh: line 44: !tokenKey: unbound variable
Error: Process completed with exit code 1.
```

No idea why because we have a secret variable `ATLEN_BUMP_TOKEN` in
the repo settings 🤷