### PR TITLE
fix: missing env variables for 2 apis

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,9 @@ jobs:
           GITLAB_BUMP_TOKEN: ${{ secrets.GITLAB_BUMP_TOKEN }}
           REALWORLD_BUMP_TOKEN: ${{ secrets.REALWORLD_BUMP_TOKEN }}
           ASI_BUMP_TOKEN: ${{ secrets.ASI_BUMP_TOKEN }}
+          ATLAN_BUMP_TOKEN: ${{ secrets.ATLAN_BUMP_TOKEN }}
           AXONAUT_BUMP_TOKEN: ${{ secrets.AXONAUT_BUMP_TOKEN }}
+          CHECKR_BUMP_TOKEN: ${{ secrets.CHECKR_BUMP_TOKEN }}
           FAIRJUNGLE_BUMP_TOKEN: ${{ secrets.FAIRJUNGLE_BUMP_TOKEN }}
           GALISE_BUMP_TOKEN: ${{ secrets.GALISE_BUMP_TOKEN }}
           GITGUARDIAN_BUMP_TOKEN: ${{ secrets.GITGUARDIAN_BUMP_TOKEN }}

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,10 +1,6 @@
 name: API diff on Pull Requests
 
 on:
-  pull_request:
-    branches:
-      - main
-
   pull_request_target:
     branches:
       - main
@@ -16,7 +12,6 @@ permissions:
 
 jobs:
   realworld-api-diff:
-    if: ${{ github.event_name == 'pull_request_target' }}
     name: Check public Realworld API diff on Bump
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +26,6 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   gitlab-api-diff:
-    if: ${{ github.event_name == 'pull_request_target' }}
     name: Check public Gitlab API diff on Bump
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   greenly-api-diff:
-    if: ${{ github.event_name == 'pull_request' }}
     name: Check Greenly API diff on Bump
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It seems there was some missing tokens for some APIs introduced by
PR #30 

This commit makes sure the automatic workflow on the `main` branch
gets fixed!