### PR TITLE
demo(train): put the mocking server in first position

### DIFF
--- a/hubs/my-train-company/trainbook-openapi-source.yaml
+++ b/hubs/my-train-company/trainbook-openapi-source.yaml
@@ -19,12 +19,12 @@ info:
     url: https://github.com/bump-sh-examples/train-travel-api/issues/new
 
 servers:
-  - url: https://api.example.com
-    description: Production
-    x-internal: false
-  
   - url: https://try.microcks.io/rest/Train+Travel+API/1.0.0
     description: Mock Server
+    x-internal: false
+
+  - url: https://api.example.com
+    description: Production
     x-internal: false
 
 security:


### PR DESCRIPTION
In order to use the mocking server by default when a user first lands
on the API explorer, let's put it in first position.